### PR TITLE
[TS] Proposed Fix: LPS-78984 portal-search-api: use original functionality by default

### DIFF
--- a/modules/apps/foundation/portal-search/portal-search-api/src/main/java/com/liferay/portal/search/configuration/DefaultSearchResultPermissionFilterConfiguration.java
+++ b/modules/apps/foundation/portal-search/portal-search-api/src/main/java/com/liferay/portal/search/configuration/DefaultSearchResultPermissionFilterConfiguration.java
@@ -32,7 +32,7 @@ import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClass
 public interface DefaultSearchResultPermissionFilterConfiguration {
 
 	@Meta.AD(
-		deflt = "100",
+		deflt = "0",
 		description = "permission-filtered-search-result-accurate-count-threshold-help",
 		name = "permission-filtered-search-result-accurate-count-threshold",
 		required = false


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-78984

Hi @slnn, 

Can you verify if this proposed fix resolves the regression bug?
This is in reply to the issue regarding the performance regression on AssetPublisher.

**Note** 
Since this changes the default value for a configuration, make sure we test with a clean bundle/database. 

Otherwise, we would have to manually change the configuration by:

1. Navigate to Control Panel -> Configuration -> System Settings
    * Navigate to Content Management -> Search
        * Select Default Search Result Permission Filter
 2. Modify: Permission Filtered Search Result Accurate Count Threshold
     * Change this value to 0

Thanks!

----
**Additional Details**
The fix is simply just changing the default value of the newly introduced configuration option to 0.

Setting a value of 0 would restore the original functionality and should resolve the performance regression.