### PR TITLE
LPS-87243 Generate consistent compoenntId

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/soy/ManagementToolbarTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/soy/ManagementToolbarTag.java
@@ -62,7 +62,7 @@ public class ManagementToolbarTag extends BaseClayTag {
 			putValue("cacheState", true);
 
 			if (Validator.isNull(componentId)) {
-				setComponentId("managementToolbar_" + searchContainerId);
+				setComponentId(searchContainerId + "ManagementToolbar");
 			}
 		}
 

--- a/modules/apps/frontend-taglib/frontend-taglib-soy/src/main/java/com/liferay/frontend/taglib/soy/servlet/taglib/TemplateRendererTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-soy/src/main/java/com/liferay/frontend/taglib/soy/servlet/taglib/TemplateRendererTag.java
@@ -100,10 +100,6 @@ public class TemplateRendererTag extends ParamAndPropertyAncestorTagImpl {
 	}
 
 	public String getComponentId() {
-		if (Validator.isNull(_componentId)) {
-			_componentId = StringUtil.randomId();
-		}
-
 		return _componentId;
 	}
 
@@ -129,6 +125,26 @@ public class TemplateRendererTag extends ParamAndPropertyAncestorTagImpl {
 
 	public String getTemplateNamespace() {
 		return _templateNamespace;
+	}
+
+	public String getWrapperId() {
+		if (_wrapperId != null) {
+			return _wrapperId;
+		}
+
+		Map<String, Object> context = getContext();
+
+		_wrapperId = (String)context.get("id");
+
+		if (Validator.isNull(_wrapperId)) {
+			_wrapperId = getComponentId();
+
+			if (Validator.isNull(_wrapperId)) {
+				_wrapperId = StringUtil.randomId();
+			}
+		}
+
+		return _wrapperId;
 	}
 
 	public void putHTMLValue(String key, String value) {
@@ -202,7 +218,7 @@ public class TemplateRendererTag extends ParamAndPropertyAncestorTagImpl {
 	}
 
 	protected String getElementSelector() {
-		String selector = StringPool.POUND.concat(getComponentId());
+		String selector = StringPool.POUND.concat(getWrapperId());
 
 		if (isWrapper()) {
 			selector = selector.concat(" > *:first-child");
@@ -251,7 +267,7 @@ public class TemplateRendererTag extends ParamAndPropertyAncestorTagImpl {
 		}
 
 		String componentJavaScript = SoyJavaScriptRendererUtil.getJavaScript(
-			context, getComponentId(), requiredModules, isWrapper());
+			context, getWrapperId(), requiredModules, isWrapper());
 
 		ScriptTag.doTag(
 			null, null, null, componentJavaScript, getBodyContent(),
@@ -265,7 +281,7 @@ public class TemplateRendererTag extends ParamAndPropertyAncestorTagImpl {
 		boolean wrapper = isWrapper();
 
 		if (!wrapper && !context.containsKey("id")) {
-			context.put("id", getComponentId());
+			context.put("id", getWrapperId());
 		}
 
 		_template.putAll(context);
@@ -276,7 +292,7 @@ public class TemplateRendererTag extends ParamAndPropertyAncestorTagImpl {
 
 		if (wrapper) {
 			jspWriter.append("<div id=\"");
-			jspWriter.append(HtmlUtil.escapeAttribute(getComponentId()));
+			jspWriter.append(HtmlUtil.escapeAttribute(getWrapperId()));
 			jspWriter.append("\">");
 		}
 
@@ -301,5 +317,6 @@ public class TemplateRendererTag extends ParamAndPropertyAncestorTagImpl {
 	private Template _template;
 	private String _templateNamespace;
 	private Boolean _wrapper;
+	private String _wrapperId;
 
 }

--- a/portal-impl/src/com/liferay/portal/spring/aop/AopConfigurableApplicationContextConfigurator.java
+++ b/portal-impl/src/com/liferay/portal/spring/aop/AopConfigurableApplicationContextConfigurator.java
@@ -331,13 +331,8 @@ public class AopConfigurableApplicationContextConfigurator
 					liferayHibernateSessionFactory);
 			}
 
-			try {
-				return TransactionManagerFactory.createTransactionManager(
-					liferayDataSource, liferayHibernateSessionFactory);
-			}
-			catch (ReflectiveOperationException roe) {
-				return ReflectionUtil.throwException(roe);
-			}
+			return TransactionManagerFactory.createTransactionManager(
+				liferayDataSource, liferayHibernateSessionFactory);
 		}
 
 		private final ClassLoader _classLoader;


### PR DESCRIPTION
Hey Lily!

This should fix the performance regression introduced by LPS-85979. Could you please check so we can avoid having to revert?

The code in `getComponentId()` was causing the Tag to always fall through `renderJavaScript` when it shouldn't. This should avoid it.