### PR TITLE
LPS-119985 Asset

### DIFF
--- a/modules/util/portal-tools-sample-sql-builder/src/main/java/com/liferay/portal/tools/sample/sql/builder/DataFactory.java
+++ b/modules/util/portal-tools-sample-sql-builder/src/main/java/com/liferay/portal/tools/sample/sql/builder/DataFactory.java
@@ -484,20 +484,6 @@ public class DataFactory {
 		return allAssetTagModels;
 	}
 
-	public List<AssetVocabularyModel> getAssetVocabularyModels() {
-		List<AssetVocabularyModel> allAssetVocabularyModels = new ArrayList<>();
-
-		allAssetVocabularyModels.add(_defaultAssetVocabularyModel);
-
-		for (List<AssetVocabularyModel> assetVocabularyModels :
-				_assetVocabularyModelsArray) {
-
-			allAssetVocabularyModels.addAll(assetVocabularyModels);
-		}
-
-		return allAssetVocabularyModels;
-	}
-
 	public long getBlogsEntryClassNameId() {
 		return getClassNameId(BlogsEntry.class);
 	}
@@ -671,9 +657,6 @@ public class DataFactory {
 		_assetVocabularyModelsArray =
 			(List<AssetVocabularyModel>[])
 				new List<?>[BenchmarksPropsValues.MAX_GROUP_COUNT];
-		_defaultAssetVocabularyModel = newAssetVocabularyModel(
-			_globalGroupId, _defaultUserId, null,
-			PropsValues.ASSET_VOCABULARY_DEFAULT);
 
 		StringBundler sb = new StringBundler(4);
 
@@ -1060,6 +1043,22 @@ public class DataFactory {
 				PortletConstants.DEFAULT_PREFERENCES));
 
 		return portletPreferencesModels;
+	}
+
+	public List<AssetVocabularyModel> newAssetVocabularyModels(
+		AssetVocabularyModel defaultAssetVocabularyModel) {
+
+		List<AssetVocabularyModel> allAssetVocabularyModels = new ArrayList<>();
+
+		allAssetVocabularyModels.add(defaultAssetVocabularyModel);
+
+		for (List<AssetVocabularyModel> assetVocabularyModels :
+				_assetVocabularyModelsArray) {
+
+			allAssetVocabularyModels.addAll(assetVocabularyModels);
+		}
+
+		return allAssetVocabularyModels;
 	}
 
 	public List<BlogsEntryModel> newBlogsEntryModels(long groupId) {
@@ -2044,6 +2043,12 @@ public class DataFactory {
 		ddmTemplateLinkModel.setTemplateId(templateId);
 
 		return ddmTemplateLinkModel;
+	}
+
+	public AssetVocabularyModel newDefaultAssetVocabularyModel() {
+		return newAssetVocabularyModel(
+			_globalGroupId, _defaultUserId, null,
+			PropsValues.ASSET_VOCABULARY_DEFAULT);
 	}
 
 	public DDMStructureLayoutModel newDefaultDLDDMStructureLayoutModel() {
@@ -5033,7 +5038,6 @@ public class DataFactory {
 	private final SimpleCounter _counter;
 	private final PortletPreferencesImpl
 		_defaultAssetPublisherPortletPreferencesImpl;
-	private AssetVocabularyModel _defaultAssetVocabularyModel;
 	private final long _defaultDLDDMStructureId;
 	private final long _defaultDLDDMStructureVersionId;
 	private long _defaultDLFileEntryTypeId =

--- a/modules/util/portal-tools-sample-sql-builder/src/main/java/com/liferay/portal/tools/sample/sql/builder/DataFactory.java
+++ b/modules/util/portal-tools-sample-sql-builder/src/main/java/com/liferay/portal/tools/sample/sql/builder/DataFactory.java
@@ -357,8 +357,6 @@ public class DataFactory {
 		_assetCategoryModelsMaps = newAssetCategoryModelsMaps(
 			_assetVocabularyModelsArray);
 
-		_assetTagModelsMaps = newAssetTagModelsMaps();
-
 		initJournalArticleContent();
 
 		initRoleModels();
@@ -969,26 +967,12 @@ public class DataFactory {
 	public List<AssetTagModel> newAssetTagModels() {
 		List<AssetTagModel> allAssetTagModels = new ArrayList<>();
 
-		for (Map<Long, List<AssetTagModel>> assetTagModelsMap :
-				_assetTagModelsMaps) {
-
-			for (List<AssetTagModel> assetTagModels :
-					assetTagModelsMap.values()) {
-
-				allAssetTagModels.addAll(assetTagModels);
-			}
-		}
-
-		return allAssetTagModels;
-	}
-
-	public Map<Long, List<AssetTagModel>>[] newAssetTagModelsMaps() {
-		Map<Long, List<AssetTagModel>>[] assetTagModelsMaps =
+		_assetTagModelsMaps =
 			(Map<Long, List<AssetTagModel>>[])
 				new HashMap<?, ?>[BenchmarksPropsValues.MAX_GROUP_COUNT];
 
 		for (int i = 1; i <= BenchmarksPropsValues.MAX_GROUP_COUNT; i++) {
-			List<AssetTagModel> assetTagModels = new ArrayList<>(
+			List<AssetTagModel> groupAssetTagModels = new ArrayList<>(
 				BenchmarksPropsValues.MAX_ASSET_TAG_COUNT);
 
 			for (int j = 0; j < BenchmarksPropsValues.MAX_ASSET_TAG_COUNT;
@@ -1008,12 +992,15 @@ public class DataFactory {
 					StringBundler.concat("TestTag_", i, "_", j));
 				assetTagModel.setLastPublishDate(new Date());
 
-				assetTagModels.add(assetTagModel);
+				groupAssetTagModels.add(assetTagModel);
+
+				allAssetTagModels.add(assetTagModel);
 			}
 
 			Map<Long, List<AssetTagModel>> assetTagModelsMap = new HashMap<>();
 
-			int pageSize = assetTagModels.size() / _assetClassNameIds.length;
+			int pageSize =
+				groupAssetTagModels.size() / _assetClassNameIds.length;
 
 			for (int j = 0; j < _assetClassNameIds.length; j++) {
 				int fromIndex = j * pageSize;
@@ -1021,18 +1008,18 @@ public class DataFactory {
 				int toIndex = (j + 1) * pageSize;
 
 				if (j == (_assetClassNameIds.length - 1)) {
-					toIndex = assetTagModels.size();
+					toIndex = groupAssetTagModels.size();
 				}
 
 				assetTagModelsMap.put(
 					_assetClassNameIds[j],
-					assetTagModels.subList(fromIndex, toIndex));
+					groupAssetTagModels.subList(fromIndex, toIndex));
 			}
 
-			assetTagModelsMaps[i - 1] = assetTagModelsMap;
+			_assetTagModelsMaps[i - 1] = assetTagModelsMap;
 		}
 
-		return assetTagModelsMaps;
+		return allAssetTagModels;
 	}
 
 	public List<AssetVocabularyModel> newAssetVocabularyModels(
@@ -5054,7 +5041,7 @@ public class DataFactory {
 	private final Map<Long, Integer> _assetPublisherQueryStartIndexes =
 		new HashMap<>();
 	private Map<Long, SimpleCounter>[] _assetTagCounters;
-	private final Map<Long, List<AssetTagModel>>[] _assetTagModelsMaps;
+	private Map<Long, List<AssetTagModel>>[] _assetTagModelsMaps;
 	private final List<AssetVocabularyModel>[] _assetVocabularyModelsArray;
 	private final Map<String, ClassNameModel> _classNameModels =
 		new HashMap<>();

--- a/modules/util/portal-tools-sample-sql-builder/src/main/java/com/liferay/portal/tools/sample/sql/builder/DataFactory.java
+++ b/modules/util/portal-tools-sample-sql-builder/src/main/java/com/liferay/portal/tools/sample/sql/builder/DataFactory.java
@@ -352,8 +352,12 @@ public class DataFactory {
 			(PortletPreferencesImpl)_portletPreferencesFactory.fromDefaultXML(
 				_readFile("default_asset_publisher_preference.xml"));
 
-		initAssetCategoryModels();
 		initAssetTagModels();
+
+		_assetVocabularyModelsArray = newAssetVocabularyModelsArray();
+
+		_assetCategoryModelsMaps = newAssetCategoryModelsMaps(
+			_assetVocabularyModelsArray);
 
 		initJournalArticleContent();
 
@@ -408,22 +412,6 @@ public class DataFactory {
 		}
 
 		return assetCategoryIds;
-	}
-
-	public List<AssetCategoryModel> getAssetCategoryModels() {
-		List<AssetCategoryModel> allAssetCategoryModels = new ArrayList<>();
-
-		for (Map<Long, List<AssetCategoryModel>> assetCategoryModelsMap :
-				_assetCategoryModelsMaps) {
-
-			for (List<AssetCategoryModel> assetCategoryModels :
-					assetCategoryModelsMap.values()) {
-
-				allAssetCategoryModels.addAll(assetCategoryModels);
-			}
-		}
-
-		return allAssetCategoryModels;
 	}
 
 	public List<Long> getAssetTagIds(AssetEntryModel assetEntryModel) {
@@ -650,82 +638,6 @@ public class DataFactory {
 		return getClassNameId(WikiPage.class);
 	}
 
-	public void initAssetCategoryModels() {
-		_assetCategoryModelsMaps =
-			(Map<Long, List<AssetCategoryModel>>[])
-				new HashMap<?, ?>[BenchmarksPropsValues.MAX_GROUP_COUNT];
-		_assetVocabularyModelsArray =
-			(List<AssetVocabularyModel>[])
-				new List<?>[BenchmarksPropsValues.MAX_GROUP_COUNT];
-
-		StringBundler sb = new StringBundler(4);
-
-		for (int i = 1; i <= BenchmarksPropsValues.MAX_GROUP_COUNT; i++) {
-			List<AssetVocabularyModel> assetVocabularyModels = new ArrayList<>(
-				BenchmarksPropsValues.MAX_ASSET_VUCABULARY_COUNT);
-			List<AssetCategoryModel> assetCategoryModels = new ArrayList<>(
-				BenchmarksPropsValues.MAX_ASSET_VUCABULARY_COUNT *
-					BenchmarksPropsValues.MAX_ASSET_CATEGORY_COUNT);
-
-			for (int j = 0;
-				 j < BenchmarksPropsValues.MAX_ASSET_VUCABULARY_COUNT; j++) {
-
-				sb.setIndex(0);
-
-				sb.append("TestVocabulary_");
-				sb.append(i);
-				sb.append(StringPool.UNDERLINE);
-				sb.append(j);
-
-				AssetVocabularyModel assetVocabularyModel =
-					newAssetVocabularyModel(
-						i, _sampleUserId, _SAMPLE_USER_NAME, sb.toString());
-
-				assetVocabularyModels.add(assetVocabularyModel);
-
-				for (int k = 0;
-					 k < BenchmarksPropsValues.MAX_ASSET_CATEGORY_COUNT; k++) {
-
-					sb.setIndex(0);
-
-					sb.append("TestCategory_");
-					sb.append(assetVocabularyModel.getVocabularyId());
-					sb.append(StringPool.UNDERLINE);
-					sb.append(k);
-
-					assetCategoryModels.add(
-						newAssetCategoryModel(
-							i, sb.toString(),
-							assetVocabularyModel.getVocabularyId()));
-				}
-			}
-
-			_assetVocabularyModelsArray[i - 1] = assetVocabularyModels;
-
-			Map<Long, List<AssetCategoryModel>> assetCategoryModelsMap =
-				new HashMap<>();
-
-			int pageSize =
-				assetCategoryModels.size() / _assetClassNameIds.length;
-
-			for (int j = 0; j < _assetClassNameIds.length; j++) {
-				int fromIndex = j * pageSize;
-
-				int toIndex = (j + 1) * pageSize;
-
-				if (j == (_assetClassNameIds.length - 1)) {
-					toIndex = assetCategoryModels.size();
-				}
-
-				assetCategoryModelsMap.put(
-					_assetClassNameIds[j],
-					assetCategoryModels.subList(fromIndex, toIndex));
-			}
-
-			_assetCategoryModelsMaps[i - 1] = assetCategoryModelsMap;
-		}
-	}
-
 	public void initAssetTagModels() {
 		_assetTagModelsArray =
 			(List<AssetTagModel>[])
@@ -935,6 +847,87 @@ public class DataFactory {
 		return accountModel;
 	}
 
+	public List<AssetCategoryModel> newAssetCategoryModels() {
+		List<AssetCategoryModel> allAssetCategoryModels = new ArrayList<>();
+
+		for (Map<Long, List<AssetCategoryModel>> assetCategoryModelsMap :
+				_assetCategoryModelsMaps) {
+
+			for (List<AssetCategoryModel> assetCategoryModels :
+					assetCategoryModelsMap.values()) {
+
+				allAssetCategoryModels.addAll(assetCategoryModels);
+			}
+		}
+
+		return allAssetCategoryModels;
+	}
+
+	public Map<Long, List<AssetCategoryModel>>[] newAssetCategoryModelsMaps(
+		List<AssetVocabularyModel>[] assetVocabularyModelsArray) {
+
+		Map<Long, List<AssetCategoryModel>>[] assetCategoryModelsMaps =
+			(Map<Long, List<AssetCategoryModel>>[])
+				new HashMap<?, ?>[BenchmarksPropsValues.MAX_GROUP_COUNT];
+
+		StringBundler sb = new StringBundler(4);
+
+		for (int i = 1; i <= BenchmarksPropsValues.MAX_GROUP_COUNT; i++) {
+			List<AssetVocabularyModel> assetVocabularyModels =
+				assetVocabularyModelsArray[i - 1];
+			List<AssetCategoryModel> assetCategoryModels = new ArrayList<>(
+				BenchmarksPropsValues.MAX_ASSET_VUCABULARY_COUNT *
+					BenchmarksPropsValues.MAX_ASSET_CATEGORY_COUNT);
+
+			for (int j = 0;
+				 j < BenchmarksPropsValues.MAX_ASSET_VUCABULARY_COUNT; j++) {
+
+				AssetVocabularyModel assetVocabularyModel =
+					assetVocabularyModels.get(j);
+
+				for (int k = 0;
+					 k < BenchmarksPropsValues.MAX_ASSET_CATEGORY_COUNT; k++) {
+
+					sb.setIndex(0);
+
+					sb.append("TestCategory_");
+					sb.append(assetVocabularyModel.getVocabularyId());
+					sb.append(StringPool.UNDERLINE);
+					sb.append(k);
+
+					assetCategoryModels.add(
+						newAssetCategoryModel(
+							i, sb.toString(),
+							assetVocabularyModel.getVocabularyId()));
+				}
+			}
+
+			Map<Long, List<AssetCategoryModel>> assetCategoryModelsMap =
+				new HashMap<>();
+
+			int pageSize =
+				assetCategoryModels.size() / _assetClassNameIds.length;
+
+			for (int j = 0; j < _assetClassNameIds.length; j++) {
+				int fromIndex = j * pageSize;
+
+				int toIndex = (j + 1) * pageSize;
+
+				if (j == (_assetClassNameIds.length - 1)) {
+					toIndex = assetCategoryModels.size();
+				}
+
+				assetCategoryModelsMap.put(
+					_assetClassNameIds[j],
+					assetCategoryModels.subList(fromIndex, toIndex));
+			}
+
+			assetCategoryModelsMaps[i - 1] = assetCategoryModelsMap;
+		}
+
+		return assetCategoryModelsMaps;
+	}
+
 	public AssetEntryModel newAssetEntryModel(BlogsEntryModel blogsEntryModel) {
 		return newAssetEntryModel(
 			blogsEntryModel.getGroupId(), blogsEntryModel.getCreateDate(),
@@ -1059,6 +1052,40 @@ public class DataFactory {
 		}
 
 		return allAssetVocabularyModels;
+	}
+
+	public List<AssetVocabularyModel>[] newAssetVocabularyModelsArray() {
+		List<AssetVocabularyModel>[] assetVocabularyModelsArray =
+			(List<AssetVocabularyModel>[])
+				new List<?>[BenchmarksPropsValues.MAX_GROUP_COUNT];
+
+		StringBundler sb = new StringBundler(4);
+
+		for (int i = 1; i <= BenchmarksPropsValues.MAX_GROUP_COUNT; i++) {
+			List<AssetVocabularyModel> assetVocabularyModels = new ArrayList<>(
+				BenchmarksPropsValues.MAX_ASSET_VUCABULARY_COUNT);
+
+			for (int j = 0;
+				 j < BenchmarksPropsValues.MAX_ASSET_VUCABULARY_COUNT; j++) {
+
+				sb.setIndex(0);
+
+				sb.append("TestVocabulary_");
+				sb.append(i);
+				sb.append(StringPool.UNDERLINE);
+				sb.append(j);
+
+				AssetVocabularyModel assetVocabularyModel =
+					newAssetVocabularyModel(
+						i, _sampleUserId, _SAMPLE_USER_NAME, sb.toString());
+
+				assetVocabularyModels.add(assetVocabularyModel);
+			}
+
+			assetVocabularyModelsArray[i - 1] = assetVocabularyModels;
+		}
+
+		return assetVocabularyModelsArray;
 	}
 
 	public List<BlogsEntryModel> newBlogsEntryModels(long groupId) {
@@ -5022,7 +5049,8 @@ public class DataFactory {
 	private final long _accountId;
 	private RoleModel _administratorRoleModel;
 	private Map<Long, SimpleCounter>[] _assetCategoryCounters;
-	private Map<Long, List<AssetCategoryModel>>[] _assetCategoryModelsMaps;
+	private final Map<Long, List<AssetCategoryModel>>[]
+		_assetCategoryModelsMaps;
 	private final long[] _assetClassNameIds;
 	private final Map<Long, Integer> _assetClassNameIdsIndexes =
 		new HashMap<>();
@@ -5031,7 +5059,7 @@ public class DataFactory {
 	private Map<Long, SimpleCounter>[] _assetTagCounters;
 	private List<AssetTagModel>[] _assetTagModelsArray;
 	private Map<Long, List<AssetTagModel>>[] _assetTagModelsMaps;
-	private List<AssetVocabularyModel>[] _assetVocabularyModelsArray;
+	private final List<AssetVocabularyModel>[] _assetVocabularyModelsArray;
 	private final Map<String, ClassNameModel> _classNameModels =
 		new HashMap<>();
 	private final long _companyId;

--- a/modules/util/portal-tools-sample-sql-builder/src/main/java/com/liferay/portal/tools/sample/sql/builder/DataFactory.java
+++ b/modules/util/portal-tools-sample-sql-builder/src/main/java/com/liferay/portal/tools/sample/sql/builder/DataFactory.java
@@ -352,8 +352,6 @@ public class DataFactory {
 			(PortletPreferencesImpl)_portletPreferencesFactory.fromDefaultXML(
 				_readFile("default_asset_publisher_preference.xml"));
 
-		_assetVocabularyModelsArray = newAssetVocabularyModelsArray();
-
 		initJournalArticleContent();
 
 		initRoleModels();
@@ -1014,25 +1012,16 @@ public class DataFactory {
 
 		allAssetVocabularyModels.add(defaultAssetVocabularyModel);
 
-		for (List<AssetVocabularyModel> assetVocabularyModels :
-				_assetVocabularyModelsArray) {
-
-			allAssetVocabularyModels.addAll(assetVocabularyModels);
-		}
-
-		return allAssetVocabularyModels;
-	}
-
-	public List<AssetVocabularyModel>[] newAssetVocabularyModelsArray() {
-		List<AssetVocabularyModel>[] assetVocabularyModelsArray =
+		_assetVocabularyModelsArray =
 			(List<AssetVocabularyModel>[])
 				new List<?>[BenchmarksPropsValues.MAX_GROUP_COUNT];
 
 		StringBundler sb = new StringBundler(4);
 
 		for (int i = 1; i <= BenchmarksPropsValues.MAX_GROUP_COUNT; i++) {
-			List<AssetVocabularyModel> assetVocabularyModels = new ArrayList<>(
-				BenchmarksPropsValues.MAX_ASSET_VUCABULARY_COUNT);
+			List<AssetVocabularyModel> groupAssetVocabularyModels =
+				new ArrayList<>(
+					BenchmarksPropsValues.MAX_ASSET_VUCABULARY_COUNT);
 
 			for (int j = 0;
 				 j < BenchmarksPropsValues.MAX_ASSET_VUCABULARY_COUNT; j++) {
@@ -1048,13 +1037,15 @@ public class DataFactory {
 					newAssetVocabularyModel(
 						i, _sampleUserId, _SAMPLE_USER_NAME, sb.toString());
 
-				assetVocabularyModels.add(assetVocabularyModel);
+				groupAssetVocabularyModels.add(assetVocabularyModel);
+
+				allAssetVocabularyModels.add(assetVocabularyModel);
 			}
 
-			assetVocabularyModelsArray[i - 1] = assetVocabularyModels;
+			_assetVocabularyModelsArray[i - 1] = groupAssetVocabularyModels;
 		}
 
-		return assetVocabularyModelsArray;
+		return allAssetVocabularyModels;
 	}
 
 	public List<BlogsEntryModel> newBlogsEntryModels(long groupId) {
@@ -5026,7 +5017,7 @@ public class DataFactory {
 		new HashMap<>();
 	private Map<Long, SimpleCounter>[] _assetTagCounters;
 	private Map<Long, List<AssetTagModel>>[] _assetTagModelsMaps;
-	private final List<AssetVocabularyModel>[] _assetVocabularyModelsArray;
+	private List<AssetVocabularyModel>[] _assetVocabularyModelsArray;
 	private final Map<String, ClassNameModel> _classNameModels =
 		new HashMap<>();
 	private final long _companyId;

--- a/modules/util/portal-tools-sample-sql-builder/src/main/java/com/liferay/portal/tools/sample/sql/builder/DataFactory.java
+++ b/modules/util/portal-tools-sample-sql-builder/src/main/java/com/liferay/portal/tools/sample/sql/builder/DataFactory.java
@@ -354,9 +354,6 @@ public class DataFactory {
 
 		_assetVocabularyModelsArray = newAssetVocabularyModelsArray();
 
-		_assetCategoryModelsMaps = newAssetCategoryModelsMaps(
-			_assetVocabularyModelsArray);
-
 		initJournalArticleContent();
 
 		initRoleModels();
@@ -776,23 +773,7 @@ public class DataFactory {
 	public List<AssetCategoryModel> newAssetCategoryModels() {
 		List<AssetCategoryModel> allAssetCategoryModels = new ArrayList<>();
 
-		for (Map<Long, List<AssetCategoryModel>> assetCategoryModelsMap :
-				_assetCategoryModelsMaps) {
-
-			for (List<AssetCategoryModel> assetCategoryModels :
-					assetCategoryModelsMap.values()) {
-
-				allAssetCategoryModels.addAll(assetCategoryModels);
-			}
-		}
-
-		return allAssetCategoryModels;
-	}
-
-	public Map<Long, List<AssetCategoryModel>>[] newAssetCategoryModelsMaps(
-		List<AssetVocabularyModel>[] assetVocabularyModelsArray) {
-
-		Map<Long, List<AssetCategoryModel>>[] assetCategoryModelsMaps =
+		_assetCategoryModelsMaps =
 			(Map<Long, List<AssetCategoryModel>>[])
 				new HashMap<?, ?>[BenchmarksPropsValues.MAX_GROUP_COUNT];
 
@@ -800,8 +781,8 @@ public class DataFactory {
 
 		for (int i = 1; i <= BenchmarksPropsValues.MAX_GROUP_COUNT; i++) {
 			List<AssetVocabularyModel> assetVocabularyModels =
-				assetVocabularyModelsArray[i - 1];
-			List<AssetCategoryModel> assetCategoryModels = new ArrayList<>(
+				_assetVocabularyModelsArray[i - 1];
+			List<AssetCategoryModel> groupAssetCategoryModels = new ArrayList<>(
 				BenchmarksPropsValues.MAX_ASSET_VUCABULARY_COUNT *
 					BenchmarksPropsValues.MAX_ASSET_CATEGORY_COUNT);
 
@@ -821,10 +802,14 @@ public class DataFactory {
 					sb.append(StringPool.UNDERLINE);
 					sb.append(k);
 
-					assetCategoryModels.add(
+					AssetCategoryModel assetCategoryModel =
 						newAssetCategoryModel(
 							i, sb.toString(),
-							assetVocabularyModel.getVocabularyId()));
+							assetVocabularyModel.getVocabularyId());
+
+					groupAssetCategoryModels.add(assetCategoryModel);
+
+					allAssetCategoryModels.add(assetCategoryModel);
 				}
 			}
 
@@ -832,7 +817,7 @@ public class DataFactory {
 				new HashMap<>();
 
 			int pageSize =
-				assetCategoryModels.size() / _assetClassNameIds.length;
+				groupAssetCategoryModels.size() / _assetClassNameIds.length;
 
 			for (int j = 0; j < _assetClassNameIds.length; j++) {
 				int fromIndex = j * pageSize;
@@ -840,18 +825,18 @@ public class DataFactory {
 				int toIndex = (j + 1) * pageSize;
 
 				if (j == (_assetClassNameIds.length - 1)) {
-					toIndex = assetCategoryModels.size();
+					toIndex = groupAssetCategoryModels.size();
 				}
 
 				assetCategoryModelsMap.put(
 					_assetClassNameIds[j],
-					assetCategoryModels.subList(fromIndex, toIndex));
+					groupAssetCategoryModels.subList(fromIndex, toIndex));
 			}
 
-			assetCategoryModelsMaps[i - 1] = assetCategoryModelsMap;
+			_assetCategoryModelsMaps[i - 1] = assetCategoryModelsMap;
 		}
 
-		return assetCategoryModelsMaps;
+		return allAssetCategoryModels;
 	}
 
 	public AssetEntryModel newAssetEntryModel(BlogsEntryModel blogsEntryModel) {
@@ -5033,8 +5018,7 @@ public class DataFactory {
 	private final long _accountId;
 	private RoleModel _administratorRoleModel;
 	private Map<Long, SimpleCounter>[] _assetCategoryCounters;
-	private final Map<Long, List<AssetCategoryModel>>[]
-		_assetCategoryModelsMaps;
+	private Map<Long, List<AssetCategoryModel>>[] _assetCategoryModelsMaps;
 	private final long[] _assetClassNameIds;
 	private final Map<Long, Integer> _assetClassNameIdsIndexes =
 		new HashMap<>();

--- a/modules/util/portal-tools-sample-sql-builder/src/main/java/com/liferay/portal/tools/sample/sql/builder/DataFactory.java
+++ b/modules/util/portal-tools-sample-sql-builder/src/main/java/com/liferay/portal/tools/sample/sql/builder/DataFactory.java
@@ -352,12 +352,12 @@ public class DataFactory {
 			(PortletPreferencesImpl)_portletPreferencesFactory.fromDefaultXML(
 				_readFile("default_asset_publisher_preference.xml"));
 
-		initAssetTagModels();
-
 		_assetVocabularyModelsArray = newAssetVocabularyModelsArray();
 
 		_assetCategoryModelsMaps = newAssetCategoryModelsMaps(
 			_assetVocabularyModelsArray);
+
+		_assetTagModelsMaps = newAssetTagModelsMaps();
 
 		initJournalArticleContent();
 
@@ -454,22 +454,6 @@ public class DataFactory {
 		}
 
 		return assetTagIds;
-	}
-
-	public List<AssetTagModel> getAssetTagModels() {
-		List<AssetTagModel> allAssetTagModels = new ArrayList<>();
-
-		for (Map<Long, List<AssetTagModel>> assetTagModelsMap :
-				_assetTagModelsMaps) {
-
-			for (List<AssetTagModel> assetTagModels :
-					assetTagModelsMap.values()) {
-
-				allAssetTagModels.addAll(assetTagModels);
-			}
-		}
-
-		return allAssetTagModels;
 	}
 
 	public long getBlogsEntryClassNameId() {
@@ -636,62 +620,6 @@ public class DataFactory {
 
 	public long getWikiPageClassNameId() {
 		return getClassNameId(WikiPage.class);
-	}
-
-	public void initAssetTagModels() {
-		_assetTagModelsArray =
-			(List<AssetTagModel>[])
-				new List<?>[BenchmarksPropsValues.MAX_GROUP_COUNT];
-		_assetTagModelsMaps =
-			(Map<Long, List<AssetTagModel>>[])
-				new HashMap<?, ?>[BenchmarksPropsValues.MAX_GROUP_COUNT];
-
-		for (int i = 1; i <= BenchmarksPropsValues.MAX_GROUP_COUNT; i++) {
-			List<AssetTagModel> assetTagModels = new ArrayList<>(
-				BenchmarksPropsValues.MAX_ASSET_TAG_COUNT);
-
-			for (int j = 0; j < BenchmarksPropsValues.MAX_ASSET_TAG_COUNT;
-				 j++) {
-
-				AssetTagModel assetTagModel = new AssetTagModelImpl();
-
-				assetTagModel.setUuid(SequentialUUID.generate());
-				assetTagModel.setTagId(_counter.get());
-				assetTagModel.setGroupId(i);
-				assetTagModel.setCompanyId(_companyId);
-				assetTagModel.setUserId(_sampleUserId);
-				assetTagModel.setUserName(_SAMPLE_USER_NAME);
-				assetTagModel.setCreateDate(new Date());
-				assetTagModel.setModifiedDate(new Date());
-				assetTagModel.setName(
-					StringBundler.concat("TestTag_", i, "_", j));
-				assetTagModel.setLastPublishDate(new Date());
-
-				assetTagModels.add(assetTagModel);
-			}
-
-			_assetTagModelsArray[i - 1] = assetTagModels;
-
-			Map<Long, List<AssetTagModel>> assetTagModelsMap = new HashMap<>();
-
-			int pageSize = assetTagModels.size() / _assetClassNameIds.length;
-
-			for (int j = 0; j < _assetClassNameIds.length; j++) {
-				int fromIndex = j * pageSize;
-
-				int toIndex = (j + 1) * pageSize;
-
-				if (j == (_assetClassNameIds.length - 1)) {
-					toIndex = assetTagModels.size();
-				}
-
-				assetTagModelsMap.put(
-					_assetClassNameIds[j],
-					assetTagModels.subList(fromIndex, toIndex));
-			}
-
-			_assetTagModelsMaps[i - 1] = assetTagModelsMap;
-		}
 	}
 
 	public void initJournalArticleContent() {
@@ -1036,6 +964,75 @@ public class DataFactory {
 				PortletConstants.DEFAULT_PREFERENCES));
 
 		return portletPreferencesModels;
+	}
+
+	public List<AssetTagModel> newAssetTagModels() {
+		List<AssetTagModel> allAssetTagModels = new ArrayList<>();
+
+		for (Map<Long, List<AssetTagModel>> assetTagModelsMap :
+				_assetTagModelsMaps) {
+
+			for (List<AssetTagModel> assetTagModels :
+					assetTagModelsMap.values()) {
+
+				allAssetTagModels.addAll(assetTagModels);
+			}
+		}
+
+		return allAssetTagModels;
+	}
+
+	public Map<Long, List<AssetTagModel>>[] newAssetTagModelsMaps() {
+		Map<Long, List<AssetTagModel>>[] assetTagModelsMaps =
+			(Map<Long, List<AssetTagModel>>[])
+				new HashMap<?, ?>[BenchmarksPropsValues.MAX_GROUP_COUNT];
+
+		for (int i = 1; i <= BenchmarksPropsValues.MAX_GROUP_COUNT; i++) {
+			List<AssetTagModel> assetTagModels = new ArrayList<>(
+				BenchmarksPropsValues.MAX_ASSET_TAG_COUNT);
+
+			for (int j = 0; j < BenchmarksPropsValues.MAX_ASSET_TAG_COUNT;
+				 j++) {
+
+				AssetTagModel assetTagModel = new AssetTagModelImpl();
+
+				assetTagModel.setUuid(SequentialUUID.generate());
+				assetTagModel.setTagId(_counter.get());
+				assetTagModel.setGroupId(i);
+				assetTagModel.setCompanyId(_companyId);
+				assetTagModel.setUserId(_sampleUserId);
+				assetTagModel.setUserName(_SAMPLE_USER_NAME);
+				assetTagModel.setCreateDate(new Date());
+				assetTagModel.setModifiedDate(new Date());
+				assetTagModel.setName(
+					StringBundler.concat("TestTag_", i, "_", j));
+				assetTagModel.setLastPublishDate(new Date());
+
+				assetTagModels.add(assetTagModel);
+			}
+
+			Map<Long, List<AssetTagModel>> assetTagModelsMap = new HashMap<>();
+
+			int pageSize = assetTagModels.size() / _assetClassNameIds.length;
+
+			for (int j = 0; j < _assetClassNameIds.length; j++) {
+				int fromIndex = j * pageSize;
+
+				int toIndex = (j + 1) * pageSize;
+
+				if (j == (_assetClassNameIds.length - 1)) {
+					toIndex = assetTagModels.size();
+				}
+
+				assetTagModelsMap.put(
+					_assetClassNameIds[j],
+					assetTagModels.subList(fromIndex, toIndex));
+			}
+
+			assetTagModelsMaps[i - 1] = assetTagModelsMap;
+		}
+
+		return assetTagModelsMaps;
 	}
 
 	public List<AssetVocabularyModel> newAssetVocabularyModels(
@@ -5057,8 +5054,7 @@ public class DataFactory {
 	private final Map<Long, Integer> _assetPublisherQueryStartIndexes =
 		new HashMap<>();
 	private Map<Long, SimpleCounter>[] _assetTagCounters;
-	private List<AssetTagModel>[] _assetTagModelsArray;
-	private Map<Long, List<AssetTagModel>>[] _assetTagModelsMaps;
+	private final Map<Long, List<AssetTagModel>>[] _assetTagModelsMaps;
 	private final List<AssetVocabularyModel>[] _assetVocabularyModelsArray;
 	private final Map<String, ClassNameModel> _classNameModels =
 		new HashMap<>();

--- a/modules/util/portal-tools-sample-sql-builder/src/main/java/com/liferay/portal/tools/sample/sql/builder/DataFactory.java
+++ b/modules/util/portal-tools-sample-sql-builder/src/main/java/com/liferay/portal/tools/sample/sql/builder/DataFactory.java
@@ -1005,12 +1005,13 @@ public class DataFactory {
 		return allAssetTagModels;
 	}
 
-	public List<AssetVocabularyModel> newAssetVocabularyModels(
-		AssetVocabularyModel defaultAssetVocabularyModel) {
-
+	public List<AssetVocabularyModel> newAssetVocabularyModels() {
 		List<AssetVocabularyModel> allAssetVocabularyModels = new ArrayList<>();
 
-		allAssetVocabularyModels.add(defaultAssetVocabularyModel);
+		allAssetVocabularyModels.add(
+			newAssetVocabularyModel(
+				_globalGroupId, _defaultUserId, null,
+				PropsValues.ASSET_VOCABULARY_DEFAULT));
 
 		_assetVocabularyModelsArray =
 			(List<AssetVocabularyModel>[])
@@ -2030,12 +2031,6 @@ public class DataFactory {
 		ddmTemplateLinkModel.setTemplateId(templateId);
 
 		return ddmTemplateLinkModel;
-	}
-
-	public AssetVocabularyModel newDefaultAssetVocabularyModel() {
-		return newAssetVocabularyModel(
-			_globalGroupId, _defaultUserId, null,
-			PropsValues.ASSET_VOCABULARY_DEFAULT);
 	}
 
 	public DDMStructureLayoutModel newDefaultDLDDMStructureLayoutModel() {

--- a/modules/util/portal-tools-sample-sql-builder/src/main/resources/com/liferay/portal/tools/sample/sql/builder/dependencies/asset.ftl
+++ b/modules/util/portal-tools-sample-sql-builder/src/main/resources/com/liferay/portal/tools/sample/sql/builder/dependencies/asset.ftl
@@ -1,4 +1,4 @@
-<#list dataFactory.assetVocabularyModels as assetVocabularyModel>
+<#list dataFactory.newAssetVocabularyModels(dataFactory.newDefaultAssetVocabularyModel()) as assetVocabularyModel>
 	${dataFactory.toInsertSQL(assetVocabularyModel)}
 </#list>
 

--- a/modules/util/portal-tools-sample-sql-builder/src/main/resources/com/liferay/portal/tools/sample/sql/builder/dependencies/asset.ftl
+++ b/modules/util/portal-tools-sample-sql-builder/src/main/resources/com/liferay/portal/tools/sample/sql/builder/dependencies/asset.ftl
@@ -2,7 +2,7 @@
 	${dataFactory.toInsertSQL(assetVocabularyModel)}
 </#list>
 
-<#list dataFactory.assetCategoryModels as assetCategoryModel>
+<#list dataFactory.newAssetCategoryModels() as assetCategoryModel>
 	${dataFactory.toInsertSQL(assetCategoryModel)}
 </#list>
 

--- a/modules/util/portal-tools-sample-sql-builder/src/main/resources/com/liferay/portal/tools/sample/sql/builder/dependencies/asset.ftl
+++ b/modules/util/portal-tools-sample-sql-builder/src/main/resources/com/liferay/portal/tools/sample/sql/builder/dependencies/asset.ftl
@@ -6,6 +6,6 @@
 	${dataFactory.toInsertSQL(assetCategoryModel)}
 </#list>
 
-<#list dataFactory.assetTagModels as assetTagModel>
+<#list dataFactory.newAssetTagModels() as assetTagModel>
 	${dataFactory.toInsertSQL(assetTagModel)}
 </#list>

--- a/modules/util/portal-tools-sample-sql-builder/src/main/resources/com/liferay/portal/tools/sample/sql/builder/dependencies/asset.ftl
+++ b/modules/util/portal-tools-sample-sql-builder/src/main/resources/com/liferay/portal/tools/sample/sql/builder/dependencies/asset.ftl
@@ -1,4 +1,4 @@
-<#list dataFactory.newAssetVocabularyModels(dataFactory.newDefaultAssetVocabularyModel()) as assetVocabularyModel>
+<#list dataFactory.newAssetVocabularyModels() as assetVocabularyModel>
 	${dataFactory.toInsertSQL(assetVocabularyModel)}
 </#list>
 


### PR DESCRIPTION
@slnn I made some simplifying changes, it passes the unit test. Please verify to make sure I didn't break anything.

Could you try to make some extra changes?

For example, vocabulary models are used by category models creation, as a category needs a vocabulary id. I think it's better to show this relationship in FTL.

Could you try this: pass the `List<AssetVocabulary>` returned by `newAssetVocabularyModels()` to `newAssetCategoryModels()`, and directly iterate on this list instead of 0 to MAX_ASSET_VOCABULARY_COUNT, so the code may look like

```
for (AssetVocabularyModel avm : assetVocabularyModels) {
    if (avm.getGroupId() != i) {
        continue;
    }

    for (int k=0; ....

....
```

And you can remove the `List<AssetVocabularyModel>[]` array from `DataFactory`.

Please also think about whether there's anything else that we can improve.