### PR TITLE
LPS-125348 pr-1852

### DIFF
--- a/modules/util/portal-tools-sample-sql-builder/src/main/java/com/liferay/portal/tools/sample/sql/builder/DataFactory.java
+++ b/modules/util/portal-tools-sample-sql-builder/src/main/java/com/liferay/portal/tools/sample/sql/builder/DataFactory.java
@@ -2145,7 +2145,7 @@ public class DataFactory {
 			ddmFieldModel.setFieldName(
 				nextDDLCustomFieldName(ddlRecordModel.getGroupId(), i - 1));
 			ddmFieldModel.setFieldType("string");
-			ddmFieldModel.setInstanceId(StringUtil.randomId());
+			ddmFieldModel.setInstanceId(StringUtil.randomString());
 			ddmFieldModel.setLocalizable(true);
 			ddmFieldModel.setPriority(i);
 


### PR DESCRIPTION
@slnn I switched to StringUtil.randomString() because portal seems to be using this (I found a DDM class using this and you can also check the data by starting portal on empty database and see DDMField table). Please test this change, thanks!