### PR TITLE
LPS 113497 4 28

### DIFF
--- a/modules/util/portal-tools-sample-sql-builder/build.gradle
+++ b/modules/util/portal-tools-sample-sql-builder/build.gradle
@@ -55,6 +55,7 @@ dependencies {
 	compileInclude project(":apps:dynamic-data-mapping:dynamic-data-mapping-service")
 	compileInclude project(":apps:dynamic-data-mapping:dynamic-data-mapping-web")
 	compileInclude project(":apps:fragment:fragment-api")
+	compileInclude project(":apps:fragment:fragment-collection-contributor:fragment-collection-contributor-basic-component")
 	compileInclude project(":apps:fragment:fragment-service")
 	compileInclude project(":apps:friendly-url:friendly-url-api")
 	compileInclude project(":apps:friendly-url:friendly-url-service")

--- a/modules/util/portal-tools-sample-sql-builder/src/main/java/com/liferay/portal/tools/sample/sql/builder/DataFactory.java
+++ b/modules/util/portal-tools-sample-sql-builder/src/main/java/com/liferay/portal/tools/sample/sql/builder/DataFactory.java
@@ -3984,6 +3984,8 @@ public class DataFactory {
 
 		Map<String, String> nameSpaces = HashMapBuilder.put(
 			_HEADING_RENDER_KEY, StringUtil.randomId()
+		).put(
+			_PARAGRAPH_RENDER_KEY, StringUtil.randomId()
 		).build();
 
 		for (LayoutModel layoutModel : layoutModels) {
@@ -3997,6 +3999,17 @@ public class DataFactory {
 					_readFile("heading_configuration.json"),
 					_readFile("heading_editValue.json"), 0,
 					nameSpaces.get(_HEADING_RENDER_KEY)));
+
+			fragmentEntryLinkModels.add(
+				newFragmentEntryLinkModel(
+					layoutModel, _PARAGRAPH_RENDER_KEY,
+					_readFile(
+						_getFragmentComponentInputStream("paragraph", "css")),
+					_readFile(
+						_getFragmentComponentInputStream("paragraph", "html")),
+					_readFile("paragraph_configuration.json"),
+					_replaceReleaseInfo(_readFile("paragraph_editValue.json")),
+					0, nameSpaces.get(_PARAGRAPH_RENDER_KEY)));
 		}
 
 		return fragmentEntryLinkModels;
@@ -7238,6 +7251,16 @@ public class DataFactory {
 		return _readFile(getResourceInputStream(resourceName));
 	}
 
+	private String _replaceReleaseInfo(String resource) throws Exception {
+		StringBundler sb = new StringBundler(3);
+
+		sb.append("Welcome to");
+		sb.append(ReleaseInfo.getReleaseInfo());
+		sb.append(StringPool.PERIOD);
+
+		return StringUtil.replace(resource, "${paragraphValue}", sb.toString());
+	}
+
 	private static final long _CURRENT_TIME = System.currentTimeMillis();
 
 	private static final long _DEFAULT_DL_FILE_ENTRY_TYPE_ID =
@@ -7252,6 +7275,9 @@ public class DataFactory {
 	private static final String _HEADING_RENDER_KEY = "BASIC_COMPONENT-heading";
 
 	private static final String _JOURNAL_STRUCTURE_KEY = "BASIC-WEB-CONTENT";
+
+	private static final String _PARAGRAPH_RENDER_KEY =
+		"BASIC_COMPONENT-paragraph";
 
 	private static final String _SAMPLE_USER_NAME = "Sample";
 

--- a/modules/util/portal-tools-sample-sql-builder/src/main/java/com/liferay/portal/tools/sample/sql/builder/DataFactory.java
+++ b/modules/util/portal-tools-sample-sql-builder/src/main/java/com/liferay/portal/tools/sample/sql/builder/DataFactory.java
@@ -267,7 +267,6 @@ import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.FastDateFormatFactoryUtil;
 import com.liferay.portal.kernel.util.FriendlyURLNormalizerUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.ObjectValuePair;
 import com.liferay.portal.kernel.util.PortletKeys;
@@ -3982,22 +3981,17 @@ public class DataFactory {
 		List<FragmentEntryLinkModel> fragmentEntryLinkModels =
 			new ArrayList<>();
 
-		Map<String, String> nameSpaces = HashMapBuilder.put(
-			_HEADING_RENDER_KEY, StringUtil.randomId()
-		).put(
-			_IMAGE_RENDER_KEY, StringUtil.randomId()
-		).put(
-			_PARAGRAPH_RENDER_KEY, StringUtil.randomId()
-		).put(
-			"LoginPortlet", StringUtil.randomId()
-		).build();
+		String headingRenderNamespace = StringUtil.randomId();
+		String imageRenderNamespace = StringUtil.randomId();
+		String paragraphRenderNamespace = StringUtil.randomId();
+		String loginPortletNamespace = StringUtil.randomId();
 
 		for (LayoutModel layoutModel : layoutModels) {
 			fragmentEntryLinkModels.add(
 				newFragmentEntryLinkModel(
 					layoutModel, "", "", "", "",
 					_readFile("loginPortlet_editValue.json"), 0,
-					nameSpaces.get("LoginPortlet")));
+					loginPortletNamespace));
 
 			fragmentEntryLinkModels.add(
 				newFragmentEntryLinkModel(
@@ -4008,7 +4002,7 @@ public class DataFactory {
 						_getFragmentComponentInputStream("heading", "html")),
 					_readFile("heading_configuration.json"),
 					_readFile("heading_editValue.json"), 0,
-					nameSpaces.get(_HEADING_RENDER_KEY)));
+					headingRenderNamespace));
 
 			fragmentEntryLinkModels.add(
 				newFragmentEntryLinkModel(
@@ -4019,7 +4013,7 @@ public class DataFactory {
 						_getFragmentComponentInputStream("paragraph", "html")),
 					_readFile("paragraph_configuration.json"),
 					_replaceReleaseInfo(_readFile("paragraph_editValue.json")),
-					0, nameSpaces.get(_PARAGRAPH_RENDER_KEY)));
+					0, paragraphRenderNamespace));
 
 			fragmentEntryLinkModels.add(
 				newFragmentEntryLinkModel(
@@ -4028,7 +4022,7 @@ public class DataFactory {
 						_getFragmentComponentInputStream("image", "html")),
 					_readFile("image_configuration.json"),
 					_readFile("image_editValue.json"), 0,
-					nameSpaces.get(_IMAGE_RENDER_KEY)));
+					imageRenderNamespace));
 		}
 
 		return fragmentEntryLinkModels;

--- a/modules/util/portal-tools-sample-sql-builder/src/main/java/com/liferay/portal/tools/sample/sql/builder/DataFactory.java
+++ b/modules/util/portal-tools-sample-sql-builder/src/main/java/com/liferay/portal/tools/sample/sql/builder/DataFactory.java
@@ -357,8 +357,6 @@ import java.lang.reflect.Method;
 
 import java.math.BigDecimal;
 
-import java.net.URL;
-
 import java.sql.Types;
 
 import java.text.Format;
@@ -3997,9 +3995,9 @@ public class DataFactory {
 				newFragmentEntryLinkModel(
 					layoutModel, _HEADING_RENDER_KEY,
 					_readFile(
-						_getFragmentComponentInputStream("heading", "css")),
+						_getFragmentComponentResourceName("heading", "css")),
 					_readFile(
-						_getFragmentComponentInputStream("heading", "html")),
+						_getFragmentComponentResourceName("heading", "html")),
 					_readFile("heading_configuration.json"),
 					_readFile("heading_editValue.json"), 0,
 					headingRenderNamespace));
@@ -4008,9 +4006,9 @@ public class DataFactory {
 				newFragmentEntryLinkModel(
 					layoutModel, _PARAGRAPH_RENDER_KEY,
 					_readFile(
-						_getFragmentComponentInputStream("paragraph", "css")),
+						_getFragmentComponentResourceName("paragraph", "css")),
 					_readFile(
-						_getFragmentComponentInputStream("paragraph", "html")),
+						_getFragmentComponentResourceName("paragraph", "html")),
 					_readFile("paragraph_configuration.json"),
 					_replaceReleaseInfo(_readFile("paragraph_editValue.json")),
 					0, paragraphRenderNamespace));
@@ -4019,7 +4017,7 @@ public class DataFactory {
 				newFragmentEntryLinkModel(
 					layoutModel, _IMAGE_RENDER_KEY, "",
 					_readFile(
-						_getFragmentComponentInputStream("image", "html")),
+						_getFragmentComponentResourceName("image", "html")),
 					_readFile("image_configuration.json"),
 					_readFile("image_editValue.json"), 0,
 					imageRenderNamespace));
@@ -5928,6 +5926,10 @@ public class DataFactory {
 
 		ClassLoader classLoader = clazz.getClassLoader();
 
+		if (resourceName.contains(StringPool.SLASH)) {
+			return classLoader.getResourceAsStream(resourceName);
+		}
+
 		return classLoader.getResourceAsStream(
 			_DEPENDENCIES_DIR + resourceName);
 	}
@@ -7242,20 +7244,12 @@ public class DataFactory {
 		return data;
 	}
 
-	private InputStream _getFragmentComponentInputStream(
-			String fragmentName, String suffix)
-		throws Exception {
+	private String _getFragmentComponentResourceName(
+		String fragmentName, String suffix) {
 
-		Class<?> clazz = getClass();
-
-		ClassLoader classLoader = clazz.getClassLoader();
-
-		URL url = classLoader.getResource(
-			StringBundler.concat(
-				"com/liferay/fragment/collection/contributor/basic/component",
-				"/dependencies/", fragmentName, "/index.", suffix));
-
-		return url.openStream();
+		return StringBundler.concat(
+			"com/liferay/fragment/collection/contributor/basic/component",
+			"/dependencies/", fragmentName, "/index.", suffix);
 	}
 
 	private String _getMBDiscussionCombinedClassName(Class<?> clazz) {
@@ -7354,16 +7348,12 @@ public class DataFactory {
 		return counterModel;
 	}
 
-	private String _readFile(InputStream inputStream) throws Exception {
+	private String _readFile(String resourceName) throws Exception {
 		List<String> lines = new ArrayList<>();
 
-		StringUtil.readLines(inputStream, lines);
+		StringUtil.readLines(getResourceInputStream(resourceName), lines);
 
 		return StringUtil.merge(lines, StringPool.SPACE);
-	}
-
-	private String _readFile(String resourceName) throws Exception {
-		return _readFile(getResourceInputStream(resourceName));
 	}
 
 	private String _replaceReleaseInfo(String resource) throws Exception {

--- a/modules/util/portal-tools-sample-sql-builder/src/main/java/com/liferay/portal/tools/sample/sql/builder/DataFactory.java
+++ b/modules/util/portal-tools-sample-sql-builder/src/main/java/com/liferay/portal/tools/sample/sql/builder/DataFactory.java
@@ -357,6 +357,8 @@ import java.lang.reflect.Method;
 
 import java.math.BigDecimal;
 
+import java.net.URL;
+
 import java.sql.Types;
 
 import java.text.Format;
@@ -7082,6 +7084,22 @@ public class DataFactory {
 		catch (ReflectiveOperationException reflectiveOperationException) {
 			ReflectionUtil.throwException(reflectiveOperationException);
 		}
+	}
+
+	private InputStream _getFragmentComponentInputStream(
+			String fragmentName, String suffix)
+		throws Exception {
+
+		Class<?> clazz = getClass();
+
+		ClassLoader classLoader = clazz.getClassLoader();
+
+		URL url = classLoader.getResource(
+			StringBundler.concat(
+				"com/liferay/fragment/collection/contributor/basic/component",
+				"/dependencies/", fragmentName, "/index.", suffix));
+
+		return url.openStream();
 	}
 
 	private String _getMBDiscussionCombinedClassName(Class<?> clazz) {

--- a/modules/util/portal-tools-sample-sql-builder/src/main/java/com/liferay/portal/tools/sample/sql/builder/DataFactory.java
+++ b/modules/util/portal-tools-sample-sql-builder/src/main/java/com/liferay/portal/tools/sample/sql/builder/DataFactory.java
@@ -4634,6 +4634,61 @@ public class DataFactory {
 		return layoutPageTemplateStructureRelModel;
 	}
 
+	public LayoutPageTemplateStructureRelModel
+		newLayoutPageTemplateStructureRelModel(
+			LayoutModel layoutModel,
+			LayoutPageTemplateStructureModel layoutPageTemplateStructureModel,
+			List<FragmentEntryLinkModel> fragmentEntryLinkModels,
+			String templateFileName) {
+
+		List<FragmentEntryLinkModel> targetFragmentEntryLinkModels =
+			new ArrayList<>();
+
+		for (FragmentEntryLinkModel model : fragmentEntryLinkModels) {
+			if (model.getPlid() == layoutModel.getPlid()) {
+				targetFragmentEntryLinkModels.add(model);
+			}
+		}
+
+		LayoutPageTemplateStructureRelModel
+			layoutPageTemplateStructureRelModel =
+				new LayoutPageTemplateStructureRelModelImpl();
+
+		// UUID
+
+		layoutPageTemplateStructureRelModel.setUuid(SequentialUUID.generate());
+
+		// PK fields
+
+		layoutPageTemplateStructureRelModel.setLayoutPageTemplateStructureRelId(
+			_counter.get());
+
+		// Group instance
+
+		layoutPageTemplateStructureRelModel.setGroupId(
+			layoutPageTemplateStructureModel.getGroupId());
+
+		// Audit fields
+
+		layoutPageTemplateStructureRelModel.setCompanyId(_companyId);
+		layoutPageTemplateStructureRelModel.setUserId(_sampleUserId);
+		layoutPageTemplateStructureRelModel.setUserName(_SAMPLE_USER_NAME);
+		layoutPageTemplateStructureRelModel.setCreateDate(new Date());
+		layoutPageTemplateStructureRelModel.setModifiedDate(new Date());
+
+		// Other fields
+
+		layoutPageTemplateStructureRelModel.setLayoutPageTemplateStructureId(
+			layoutPageTemplateStructureModel.
+				getLayoutPageTemplateStructureId());
+		layoutPageTemplateStructureRelModel.setSegmentsExperienceId(0L);
+
+		layoutPageTemplateStructureRelModel.setData(
+			_generateJsonData(targetFragmentEntryLinkModels, templateFileName));
+
+		return layoutPageTemplateStructureRelModel;
+	}
+
 	public List<LayoutSetModel> newLayoutSetModels(long groupId) {
 		return newLayoutSetModels(groupId, "classic_WAR_classictheme");
 	}
@@ -7144,6 +7199,53 @@ public class DataFactory {
 		catch (ReflectiveOperationException reflectiveOperationException) {
 			ReflectionUtil.throwException(reflectiveOperationException);
 		}
+	}
+
+	private String _generateJsonData(
+		List<FragmentEntryLinkModel> fragmentEntryLinkModels,
+		String templateFileName) {
+
+		String data = null;
+
+		try {
+			data = _readFile(templateFileName);
+
+			for (FragmentEntryLinkModel fragmentEntryLinkModel :
+					fragmentEntryLinkModels) {
+
+				String rendererKey = fragmentEntryLinkModel.getRendererKey();
+
+				if (rendererKey.equals(_HEADING_RENDER_KEY)) {
+					data = StringUtil.replace(
+						data, "${headingFragmentEntryLinkId}",
+						String.valueOf(
+							fragmentEntryLinkModel.getFragmentEntryLinkId()));
+				}
+				else if (rendererKey.equals(_PARAGRAPH_RENDER_KEY)) {
+					data = StringUtil.replace(
+						data, "${paragraphFragmentEntryLinkId}",
+						String.valueOf(
+							fragmentEntryLinkModel.getFragmentEntryLinkId()));
+				}
+				else if (rendererKey.equals(_IMAGE_RENDER_KEY)) {
+					data = StringUtil.replace(
+						data, "${imageFragmentEntryLinkId}",
+						String.valueOf(
+							fragmentEntryLinkModel.getFragmentEntryLinkId()));
+				}
+				else {
+					data = StringUtil.replace(
+						data, "${loginPortletFragmentEntryLinkId}",
+						String.valueOf(
+							fragmentEntryLinkModel.getFragmentEntryLinkId()));
+				}
+			}
+		}
+		catch (Exception exception) {
+			exception.printStackTrace();
+		}
+
+		return data;
 	}
 
 	private InputStream _getFragmentComponentInputStream(

--- a/modules/util/portal-tools-sample-sql-builder/src/main/java/com/liferay/portal/tools/sample/sql/builder/DataFactory.java
+++ b/modules/util/portal-tools-sample-sql-builder/src/main/java/com/liferay/portal/tools/sample/sql/builder/DataFactory.java
@@ -267,6 +267,7 @@ import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.FastDateFormatFactoryUtil;
 import com.liferay.portal.kernel.util.FriendlyURLNormalizerUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.ObjectValuePair;
 import com.liferay.portal.kernel.util.PortletKeys;
@@ -3974,6 +3975,33 @@ public class DataFactory {
 		return fragmentEntryLinkModel;
 	}
 
+	public List<FragmentEntryLinkModel> newFragmentEntryLinkModels(
+			List<LayoutModel> layoutModels)
+		throws Exception {
+
+		List<FragmentEntryLinkModel> fragmentEntryLinkModels =
+			new ArrayList<>();
+
+		Map<String, String> nameSpaces = HashMapBuilder.put(
+			_HEADING_RENDER_KEY, StringUtil.randomId()
+		).build();
+
+		for (LayoutModel layoutModel : layoutModels) {
+			fragmentEntryLinkModels.add(
+				newFragmentEntryLinkModel(
+					layoutModel, _HEADING_RENDER_KEY,
+					_readFile(
+						_getFragmentComponentInputStream("heading", "css")),
+					_readFile(
+						_getFragmentComponentInputStream("heading", "html")),
+					_readFile("heading_configuration.json"),
+					_readFile("heading_editValue.json"), 0,
+					nameSpaces.get(_HEADING_RENDER_KEY)));
+		}
+
+		return fragmentEntryLinkModels;
+	}
+
 	public FragmentEntryModel newFragmentEntryModel(
 			long groupId, FragmentCollectionModel fragmentCollectionModel)
 		throws Exception {
@@ -7220,6 +7248,8 @@ public class DataFactory {
 
 	private static final long _FUTURE_TIME =
 		System.currentTimeMillis() + Time.YEAR;
+
+	private static final String _HEADING_RENDER_KEY = "BASIC_COMPONENT-heading";
 
 	private static final String _JOURNAL_STRUCTURE_KEY = "BASIC-WEB-CONTENT";
 

--- a/modules/util/portal-tools-sample-sql-builder/src/main/java/com/liferay/portal/tools/sample/sql/builder/DataFactory.java
+++ b/modules/util/portal-tools-sample-sql-builder/src/main/java/com/liferay/portal/tools/sample/sql/builder/DataFactory.java
@@ -3985,6 +3985,8 @@ public class DataFactory {
 		Map<String, String> nameSpaces = HashMapBuilder.put(
 			_HEADING_RENDER_KEY, StringUtil.randomId()
 		).put(
+			_IMAGE_RENDER_KEY, StringUtil.randomId()
+		).put(
 			_PARAGRAPH_RENDER_KEY, StringUtil.randomId()
 		).build();
 
@@ -4010,6 +4012,15 @@ public class DataFactory {
 					_readFile("paragraph_configuration.json"),
 					_replaceReleaseInfo(_readFile("paragraph_editValue.json")),
 					0, nameSpaces.get(_PARAGRAPH_RENDER_KEY)));
+
+			fragmentEntryLinkModels.add(
+				newFragmentEntryLinkModel(
+					layoutModel, _IMAGE_RENDER_KEY, "",
+					_readFile(
+						_getFragmentComponentInputStream("image", "html")),
+					_readFile("image_configuration.json"),
+					_readFile("image_editValue.json"), 0,
+					nameSpaces.get(_IMAGE_RENDER_KEY)));
 		}
 
 		return fragmentEntryLinkModels;
@@ -7273,6 +7284,8 @@ public class DataFactory {
 		System.currentTimeMillis() + Time.YEAR;
 
 	private static final String _HEADING_RENDER_KEY = "BASIC_COMPONENT-heading";
+
+	private static final String _IMAGE_RENDER_KEY = "BASIC_COMPONENT-image";
 
 	private static final String _JOURNAL_STRUCTURE_KEY = "BASIC-WEB-CONTENT";
 

--- a/modules/util/portal-tools-sample-sql-builder/src/main/java/com/liferay/portal/tools/sample/sql/builder/DataFactory.java
+++ b/modules/util/portal-tools-sample-sql-builder/src/main/java/com/liferay/portal/tools/sample/sql/builder/DataFactory.java
@@ -3988,9 +3988,17 @@ public class DataFactory {
 			_IMAGE_RENDER_KEY, StringUtil.randomId()
 		).put(
 			_PARAGRAPH_RENDER_KEY, StringUtil.randomId()
+		).put(
+			"LoginPortlet", StringUtil.randomId()
 		).build();
 
 		for (LayoutModel layoutModel : layoutModels) {
+			fragmentEntryLinkModels.add(
+				newFragmentEntryLinkModel(
+					layoutModel, "", "", "", "",
+					_readFile("loginPortlet_editValue.json"), 0,
+					nameSpaces.get("LoginPortlet")));
+
 			fragmentEntryLinkModels.add(
 				newFragmentEntryLinkModel(
 					layoutModel, _HEADING_RENDER_KEY,

--- a/modules/util/portal-tools-sample-sql-builder/src/main/java/com/liferay/portal/tools/sample/sql/builder/DataFactory.java
+++ b/modules/util/portal-tools-sample-sql-builder/src/main/java/com/liferay/portal/tools/sample/sql/builder/DataFactory.java
@@ -6295,6 +6295,52 @@ public class DataFactory {
 			dlFolderModel, "TestFile" + index, "txt", ContentTypes.TEXT_PLAIN);
 	}
 
+	protected FragmentEntryLinkModel newFragmentEntryLinkModel(
+		LayoutModel layoutModel, String renderKey, String css, String html,
+		String configuration, String editValue, int position,
+		String nameSpace) {
+
+		FragmentEntryLinkModel fragmentEntryLinkModel =
+			new FragmentEntryLinkModelImpl();
+
+		// UUID
+
+		fragmentEntryLinkModel.setUuid(SequentialUUID.generate());
+
+		// PK fields
+
+		fragmentEntryLinkModel.setFragmentEntryLinkId(_counter.get());
+
+		// Group instance
+
+		fragmentEntryLinkModel.setGroupId(layoutModel.getGroupId());
+
+		// Audit fields
+
+		fragmentEntryLinkModel.setCompanyId(_companyId);
+		fragmentEntryLinkModel.setUserId(_sampleUserId);
+		fragmentEntryLinkModel.setUserName(_SAMPLE_USER_NAME);
+		fragmentEntryLinkModel.setCreateDate(new Date());
+		fragmentEntryLinkModel.setModifiedDate(new Date());
+
+		// Other fields
+
+		fragmentEntryLinkModel.setFragmentEntryId(0);
+		fragmentEntryLinkModel.setClassNameId(getClassNameId(Layout.class));
+		fragmentEntryLinkModel.setClassPK(layoutModel.getPlid());
+		fragmentEntryLinkModel.setPlid(layoutModel.getPlid());
+		fragmentEntryLinkModel.setRendererKey(renderKey);
+		fragmentEntryLinkModel.setConfiguration(configuration);
+		fragmentEntryLinkModel.setCss(css);
+		fragmentEntryLinkModel.setHtml(html);
+		fragmentEntryLinkModel.setConfiguration(configuration);
+		fragmentEntryLinkModel.setEditableValues(editValue);
+		fragmentEntryLinkModel.setNamespace(nameSpace);
+		fragmentEntryLinkModel.setPosition(position);
+
+		return fragmentEntryLinkModel;
+	}
+
 	protected GroupModel newGroupModel(
 		long groupId, long classNameId, long classPK, String name,
 		boolean site) {

--- a/modules/util/portal-tools-sample-sql-builder/src/main/java/com/liferay/portal/tools/sample/sql/builder/DataFactory.java
+++ b/modules/util/portal-tools-sample-sql-builder/src/main/java/com/liferay/portal/tools/sample/sql/builder/DataFactory.java
@@ -7180,12 +7180,16 @@ public class DataFactory {
 		return counterModel;
 	}
 
-	private String _readFile(String resourceName) throws Exception {
+	private String _readFile(InputStream inputStream) throws Exception {
 		List<String> lines = new ArrayList<>();
 
-		StringUtil.readLines(getResourceInputStream(resourceName), lines);
+		StringUtil.readLines(inputStream, lines);
 
 		return StringUtil.merge(lines, StringPool.SPACE);
+	}
+
+	private String _readFile(String resourceName) throws Exception {
+		return _readFile(getResourceInputStream(resourceName));
 	}
 
 	private static final long _CURRENT_TIME = System.currentTimeMillis();

--- a/modules/util/portal-tools-sample-sql-builder/src/main/java/com/liferay/portal/tools/sample/sql/builder/DataFactory.java
+++ b/modules/util/portal-tools-sample-sql-builder/src/main/java/com/liferay/portal/tools/sample/sql/builder/DataFactory.java
@@ -2284,6 +2284,23 @@ public class DataFactory {
 		return layoutModels;
 	}
 
+	public List<LayoutModel> newContentPageLayoutModels(
+		long groupId, String name) {
+
+		List<LayoutModel> layoutModels = new ArrayList<>();
+
+		LayoutModel publicLayoutModel = _newContentPageLayoutModel(
+			groupId, name, 0, 0);
+
+		layoutModels.add(publicLayoutModel);
+		layoutModels.add(
+			_newContentPageLayoutModel(
+				groupId, name + "1", getClassNameId(Layout.class),
+				publicLayoutModel.getPlid()));
+
+		return layoutModels;
+	}
+
 	public List<CounterModel> newCounterModels() {
 		return Arrays.asList(
 			_newCounterModel(Counter.class.getName()),
@@ -7044,6 +7061,68 @@ public class DataFactory {
 		sb.setIndex(sb.index() - 1);
 
 		return sb.toString();
+	}
+
+	private LayoutModel _newContentPageLayoutModel(
+		long groupId, String name, long classNameId, long classPK) {
+
+		SimpleCounter simpleCounter = _layoutCounters.get(groupId);
+
+		if (simpleCounter == null) {
+			simpleCounter = new SimpleCounter();
+
+			_layoutCounters.put(groupId, simpleCounter);
+		}
+
+		LayoutModel layoutModel = new LayoutModelImpl();
+
+		// UUID
+
+		layoutModel.setUuid(SequentialUUID.generate());
+
+		// PK fields
+
+		layoutModel.setPlid(_counter.get());
+
+		// Group instance
+
+		layoutModel.setGroupId(groupId);
+
+		// Audit fields
+
+		layoutModel.setCompanyId(_companyId);
+		layoutModel.setUserId(_sampleUserId);
+		layoutModel.setUserName(_SAMPLE_USER_NAME);
+		layoutModel.setCreateDate(new Date());
+		layoutModel.setModifiedDate(new Date());
+
+		// Other fields
+
+		layoutModel.setLayoutId(simpleCounter.get());
+		layoutModel.setName(
+			"<?xml version=\"1.0\"?><root><name>" + name + "</name></root>");
+		layoutModel.setType(LayoutConstants.TYPE_CONTENT);
+		layoutModel.setFriendlyURL(StringPool.FORWARD_SLASH + name);
+		layoutModel.setClassNameId(classNameId);
+		layoutModel.setClassPK(classPK);
+
+		if (classNameId != 0) {
+			layoutModel.setHidden(true);
+			layoutModel.setSystem(true);
+		}
+
+		UnicodeProperties typeSettingsUnicodeProperties = new UnicodeProperties(
+			true);
+
+		typeSettingsUnicodeProperties.setProperty("published", "true");
+
+		layoutModel.setTypeSettings(
+			StringUtil.replace(
+				typeSettingsUnicodeProperties.toString(), '\n', "\\n"));
+
+		layoutModel.setLastPublishDate(new Date());
+
+		return layoutModel;
 	}
 
 	private CounterModel _newCounterModel(String name) {

--- a/modules/util/portal-tools-sample-sql-builder/src/main/resources/com/liferay/portal/tools/sample/sql/builder/dependencies/data/default-homepage-layout-definition.json
+++ b/modules/util/portal-tools-sample-sql-builder/src/main/resources/com/liferay/portal/tools/sample/sql/builder/dependencies/data/default-homepage-layout-definition.json
@@ -1,0 +1,429 @@
+{
+	"deletedItems": [
+	],
+	"items": {
+		"0cd91d5e-7249-0476-ff23-c171e068cb11": {
+			"children": [
+				"3bf89137-2bdc-f334-1090-10887e87b7ad"
+			],
+			"config": {
+			},
+			"itemId": "0cd91d5e-7249-0476-ff23-c171e068cb11",
+			"parentId": "",
+			"type": "root"
+		},
+		"10585e58-7fc7-618b-4e1e-71d603fd7d8e": {
+			"children": [
+				"5fb90589-6fde-887b-fda3-1c72ecf57fa4"
+			],
+			"config": {
+				"landscapeMobile": {
+				},
+				"portraitMobile": {
+				},
+				"size": 4,
+				"tablet": {
+				}
+			},
+			"itemId": "10585e58-7fc7-618b-4e1e-71d603fd7d8e",
+			"parentId": "205c3614-4c56-7289-4a27-02ad044cdcdc",
+			"type": "column"
+		},
+		"205c3614-4c56-7289-4a27-02ad044cdcdc": {
+			"children": [
+				"d6e2cf3a-f92b-194a-0cca-7c7bdcdf8939",
+				"d4209a43-31c9-4f39-392c-540c24696bc7",
+				"10585e58-7fc7-618b-4e1e-71d603fd7d8e"
+			],
+			"config": {
+				"gutters": true,
+				"landscapeMobile": {
+					"styles": {
+					}
+				},
+				"modulesPerRow": 3,
+				"numberOfColumns": 3,
+				"portraitMobile": {
+					"styles": {
+					}
+				},
+				"reverseOrder": false,
+				"styles": {
+					"backgroundImage": {
+					},
+					"borderRadius": "",
+					"borderWidth": 0,
+					"fontFamily": "",
+					"fontSize": "",
+					"fontWeight": "",
+					"height": "",
+					"marginBottom": "",
+					"marginLeft": "",
+					"marginRight": "",
+					"marginTop": "",
+					"maxHeight": "",
+					"maxWidth": "",
+					"minHeight": "",
+					"minWidth": "",
+					"opacity": 100,
+					"overflow": "",
+					"paddingBottom": "",
+					"paddingLeft": "",
+					"paddingRight": "",
+					"paddingTop": "",
+					"shadow": "",
+					"textAlign": "",
+					"width": ""
+				},
+				"tablet": {
+					"styles": {
+					}
+				},
+				"verticalAlignment": "top"
+			},
+			"itemId": "205c3614-4c56-7289-4a27-02ad044cdcdc",
+			"parentId": "d52cf6c1-8626-b903-b478-94dc470aec56",
+			"type": "row"
+		},
+		"3bf89137-2bdc-f334-1090-10887e87b7ad": {
+			"children": [
+				"d52cf6c1-8626-b903-b478-94dc470aec56"
+			],
+			"config": {
+				"landscapeMobile": {
+					"styles": {
+					}
+				},
+				"link": {
+				},
+				"portraitMobile": {
+					"styles": {
+					}
+				},
+				"styles": {
+					"backgroundImage": {
+					},
+					"borderRadius": "",
+					"borderWidth": 0,
+					"fontFamily": "",
+					"fontSize": "",
+					"fontWeight": "",
+					"height": "",
+					"marginBottom": "",
+					"marginLeft": "",
+					"marginRight": "",
+					"marginTop": "",
+					"maxHeight": "",
+					"maxWidth": "",
+					"minHeight": "",
+					"minWidth": "",
+					"opacity": 100,
+					"overflow": "",
+					"paddingBottom": "",
+					"paddingLeft": "",
+					"paddingRight": "",
+					"paddingTop": "",
+					"shadow": "",
+					"textAlign": "",
+					"width": ""
+				},
+				"tablet": {
+					"styles": {
+					}
+				},
+				"widthType": "fluid"
+			},
+			"itemId": "3bf89137-2bdc-f334-1090-10887e87b7ad",
+			"parentId": "0cd91d5e-7249-0476-ff23-c171e068cb11",
+			"type": "container"
+		},
+		"3e7aadea-8b20-6a98-3206-0649de4a551c": {
+			"children": [
+			],
+			"config": {
+				"fragmentEntryLinkId": "${imageFragmentEntryLinkId}",
+				"landscapeMobile": {
+					"styles": {
+					}
+				},
+				"portraitMobile": {
+					"styles": {
+					}
+				},
+				"styles": {
+					"backgroundImage": {
+					},
+					"borderRadius": "",
+					"borderWidth": 0,
+					"fontFamily": "",
+					"fontSize": "",
+					"fontWeight": "",
+					"height": "",
+					"marginBottom": "",
+					"marginLeft": "",
+					"marginRight": "",
+					"marginTop": "",
+					"maxHeight": "",
+					"maxWidth": "",
+					"minHeight": "",
+					"minWidth": "",
+					"opacity": 100,
+					"overflow": "",
+					"paddingBottom": "",
+					"paddingLeft": "",
+					"paddingRight": "",
+					"paddingTop": "",
+					"shadow": "",
+					"textAlign": "",
+					"width": ""
+				},
+				"tablet": {
+					"styles": {
+					}
+				}
+			},
+			"itemId": "3e7aadea-8b20-6a98-3206-0649de4a551c",
+			"parentId": "d4209a43-31c9-4f39-392c-540c24696bc7",
+			"type": "fragment"
+		},
+		"42e5382b-32dc-3cde-201d-3490c7ec531e": {
+			"children": [
+			],
+			"config": {
+				"fragmentEntryLinkId": "${headingFragmentEntryLinkId}",
+				"landscapeMobile": {
+					"styles": {
+					}
+				},
+				"portraitMobile": {
+					"styles": {
+					}
+				},
+				"styles": {
+					"backgroundImage": {
+					},
+					"borderRadius": "",
+					"borderWidth": 0,
+					"fontFamily": "",
+					"fontSize": "",
+					"fontWeight": "",
+					"height": "",
+					"marginBottom": "",
+					"marginLeft": "",
+					"marginRight": "",
+					"marginTop": "",
+					"maxHeight": "",
+					"maxWidth": "",
+					"minHeight": "",
+					"minWidth": "",
+					"opacity": 100,
+					"overflow": "",
+					"paddingBottom": "",
+					"paddingLeft": "",
+					"paddingRight": "",
+					"paddingTop": "",
+					"shadow": "",
+					"textAlign": "",
+					"width": ""
+				},
+				"tablet": {
+					"styles": {
+					}
+				}
+			},
+			"itemId": "42e5382b-32dc-3cde-201d-3490c7ec531e",
+			"parentId": "d6e2cf3a-f92b-194a-0cca-7c7bdcdf8939",
+			"type": "fragment"
+		},
+		"5fb90589-6fde-887b-fda3-1c72ecf57fa4": {
+			"children": [
+			],
+			"config": {
+				"fragmentEntryLinkId": "${loginPortletFragmentEntryLinkId}",
+				"landscapeMobile": {
+					"styles": {
+					}
+				},
+				"portraitMobile": {
+					"styles": {
+					}
+				},
+				"styles": {
+					"backgroundImage": {
+					},
+					"borderRadius": "",
+					"borderWidth": 0,
+					"fontFamily": "",
+					"fontSize": "",
+					"fontWeight": "",
+					"height": "",
+					"marginBottom": "",
+					"marginLeft": "",
+					"marginRight": "",
+					"marginTop": "",
+					"maxHeight": "",
+					"maxWidth": "",
+					"minHeight": "",
+					"minWidth": "",
+					"opacity": 100,
+					"overflow": "",
+					"paddingBottom": "",
+					"paddingLeft": "",
+					"paddingRight": "",
+					"paddingTop": "",
+					"shadow": "",
+					"textAlign": "",
+					"width": ""
+				},
+				"tablet": {
+					"styles": {
+					}
+				}
+			},
+			"itemId": "5fb90589-6fde-887b-fda3-1c72ecf57fa4",
+			"parentId": "10585e58-7fc7-618b-4e1e-71d603fd7d8e",
+			"type": "fragment"
+		},
+		"b794ca72-8bbd-3324-e0c7-a8a79a340e0e": {
+			"children": [
+			],
+			"config": {
+				"fragmentEntryLinkId": "${paragraphFragmentEntryLinkId}",
+				"landscapeMobile": {
+					"styles": {
+					}
+				},
+				"portraitMobile": {
+					"styles": {
+					}
+				},
+				"styles": {
+					"backgroundImage": {
+					},
+					"borderRadius": "",
+					"borderWidth": 0,
+					"fontFamily": "",
+					"fontSize": "",
+					"fontWeight": "",
+					"height": "",
+					"marginBottom": "",
+					"marginLeft": "",
+					"marginRight": "",
+					"marginTop": "",
+					"maxHeight": "",
+					"maxWidth": "",
+					"minHeight": "",
+					"minWidth": "",
+					"opacity": 100,
+					"overflow": "",
+					"paddingBottom": "",
+					"paddingLeft": "",
+					"paddingRight": "",
+					"paddingTop": "",
+					"shadow": "",
+					"textAlign": "",
+					"width": ""
+				},
+				"tablet": {
+					"styles": {
+					}
+				}
+			},
+			"itemId": "b794ca72-8bbd-3324-e0c7-a8a79a340e0e",
+			"parentId": "d6e2cf3a-f92b-194a-0cca-7c7bdcdf8939",
+			"type": "fragment"
+		},
+		"d4209a43-31c9-4f39-392c-540c24696bc7": {
+			"children": [
+				"3e7aadea-8b20-6a98-3206-0649de4a551c"
+			],
+			"config": {
+				"landscapeMobile": {
+				},
+				"portraitMobile": {
+				},
+				"size": 4,
+				"tablet": {
+				}
+			},
+			"itemId": "d4209a43-31c9-4f39-392c-540c24696bc7",
+			"parentId": "205c3614-4c56-7289-4a27-02ad044cdcdc",
+			"type": "column"
+		},
+		"d52cf6c1-8626-b903-b478-94dc470aec56": {
+			"children": [
+				"205c3614-4c56-7289-4a27-02ad044cdcdc"
+			],
+			"config": {
+				"landscapeMobile": {
+					"styles": {
+					}
+				},
+				"link": {
+				},
+				"portraitMobile": {
+					"styles": {
+					}
+				},
+				"styles": {
+					"backgroundImage": {
+					},
+					"borderRadius": "",
+					"borderWidth": 0,
+					"fontFamily": "",
+					"fontSize": "",
+					"fontWeight": "",
+					"height": "",
+					"marginBottom": "",
+					"marginLeft": "",
+					"marginRight": "",
+					"marginTop": "",
+					"maxHeight": "",
+					"maxWidth": "",
+					"minHeight": "",
+					"minWidth": "",
+					"opacity": 100,
+					"overflow": "",
+					"paddingBottom": "",
+					"paddingLeft": "",
+					"paddingRight": "",
+					"paddingTop": "",
+					"shadow": "",
+					"textAlign": "",
+					"width": ""
+				},
+				"tablet": {
+					"styles": {
+					}
+				},
+				"widthType": "fluid"
+			},
+			"itemId": "d52cf6c1-8626-b903-b478-94dc470aec56",
+			"parentId": "3bf89137-2bdc-f334-1090-10887e87b7ad",
+			"type": "container"
+		},
+		"d6e2cf3a-f92b-194a-0cca-7c7bdcdf8939": {
+			"children": [
+				"42e5382b-32dc-3cde-201d-3490c7ec531e",
+				"b794ca72-8bbd-3324-e0c7-a8a79a340e0e"
+			],
+			"config": {
+				"landscapeMobile": {
+				},
+				"portraitMobile": {
+				},
+				"size": 4,
+				"tablet": {
+				}
+			},
+			"itemId": "d6e2cf3a-f92b-194a-0cca-7c7bdcdf8939",
+			"parentId": "205c3614-4c56-7289-4a27-02ad044cdcdc",
+			"type": "column"
+		}
+	},
+	"rootItems": {
+		"dropZone": "",
+		"main": "0cd91d5e-7249-0476-ff23-c171e068cb11"
+	},
+	"version": 1
+}

--- a/modules/util/portal-tools-sample-sql-builder/src/main/resources/com/liferay/portal/tools/sample/sql/builder/dependencies/data/heading_configuration.json
+++ b/modules/util/portal-tools-sample-sql-builder/src/main/resources/com/liferay/portal/tools/sample/sql/builder/dependencies/data/heading_configuration.json
@@ -1,0 +1,86 @@
+{
+	"fieldSets": [
+		{
+			"fields": [
+				{
+					"dataType": "string",
+					"defaultValue": "h1",
+					"label": "heading-level",
+					"name": "headingLevel",
+					"type": "select",
+					"typeOptions": {
+						"validValues": [
+							{
+								"value": "h1"
+							},
+							{
+								"value": "h2"
+							},
+							{
+								"value": "h3"
+							},
+							{
+								"value": "h4"
+							}
+						]
+					}
+				},
+				{
+					"dataType": "string",
+					"defaultValue": "left",
+					"label": "text-align",
+					"name": "textAlign",
+					"type": "select",
+					"typeOptions": {
+						"validValues": [
+							{
+								"value": "left"
+							},
+							{
+								"value": "center"
+							},
+							{
+								"value": "right"
+							}
+						]
+					}
+				},
+				{
+					"dataType": "string",
+					"defaultValue": "3",
+					"label": "margin-bottom",
+					"name": "marginBottom",
+					"type": "select",
+					"typeOptions": {
+						"validValues": [
+							{
+								"value": "0"
+							},
+							{
+								"value": "1"
+							},
+							{
+								"value": "2"
+							},
+							{
+								"value": "3"
+							},
+							{
+								"value": "4"
+							},
+							{
+								"value": "5"
+							}
+						]
+					}
+				},
+				{
+					"dataType": "object",
+					"label": "text-color",
+					"name": "textColor",
+					"type": "colorPalette"
+				}
+			]
+		}
+	]
+}

--- a/modules/util/portal-tools-sample-sql-builder/src/main/resources/com/liferay/portal/tools/sample/sql/builder/dependencies/data/heading_editValue.json
+++ b/modules/util/portal-tools-sample-sql-builder/src/main/resources/com/liferay/portal/tools/sample/sql/builder/dependencies/data/heading_editValue.json
@@ -1,0 +1,14 @@
+{
+	"com.liferay.fragment.entry.processor.background.image.BackgroundImageFragmentEntryProcessor": {
+	},
+	"com.liferay.fragment.entry.processor.editable.EditableFragmentEntryProcessor": {
+		"element-text": {
+			"config": {
+			},
+			"defaultValue": "Heading Example",
+			"en_US": "Hello World"
+		}
+	},
+	"com.liferay.fragment.entry.processor.freemarker.FreeMarkerFragmentEntryProcessor": {
+	}
+}

--- a/modules/util/portal-tools-sample-sql-builder/src/main/resources/com/liferay/portal/tools/sample/sql/builder/dependencies/data/image_configuration.json
+++ b/modules/util/portal-tools-sample-sql-builder/src/main/resources/com/liferay/portal/tools/sample/sql/builder/dependencies/data/image_configuration.json
@@ -1,0 +1,28 @@
+{
+	"fieldSets": [
+		{
+			"configurationRole": "style",
+			"fields": [
+				{
+					"dataType": "string",
+					"defaultValue": "w-100",
+					"label": "image-size",
+					"name": "imageSize",
+					"type": "select",
+					"typeOptions": {
+						"validValues": [
+							{
+								"label": "fit",
+								"value": "w-100"
+							},
+							{
+								"label": "original-size",
+								"value": "w-0"
+							}
+						]
+					}
+				}
+			]
+		}
+	]
+}

--- a/modules/util/portal-tools-sample-sql-builder/src/main/resources/com/liferay/portal/tools/sample/sql/builder/dependencies/data/image_editValue.json
+++ b/modules/util/portal-tools-sample-sql-builder/src/main/resources/com/liferay/portal/tools/sample/sql/builder/dependencies/data/image_editValue.json
@@ -1,0 +1,18 @@
+{
+	"com.liferay.fragment.entry.processor.background.image.BackgroundImageFragmentEntryProcessor": {
+	},
+	"com.liferay.fragment.entry.processor.editable.EditableFragmentEntryProcessor": {
+		"image-square": {
+			"config": {
+				"imageTitle": ""
+			},
+			"defaultValue": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAJCAYAAAA7KqwyAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAkSURBVHgB7cxBEQAACAIwtH8Pzw52kxD8OBZgNXsPQUOUwCIgAz0DHTyygaAAAAAASUVORK5CYII=",
+			"en_US": {
+				"url": "/welcome_bg_benchmark.png"
+			}
+		}
+	},
+	"com.liferay.fragment.entry.processor.freemarker.FreeMarkerFragmentEntryProcessor": {
+		"imageSize": "w-100"
+	}
+}

--- a/modules/util/portal-tools-sample-sql-builder/src/main/resources/com/liferay/portal/tools/sample/sql/builder/dependencies/data/loginPortlet_editValue.json
+++ b/modules/util/portal-tools-sample-sql-builder/src/main/resources/com/liferay/portal/tools/sample/sql/builder/dependencies/data/loginPortlet_editValue.json
@@ -1,0 +1,10 @@
+{
+	"com.liferay.fragment.entry.processor.background.image.BackgroundImageFragmentEntryProcessor": {
+	},
+	"com.liferay.fragment.entry.processor.editable.EditableFragmentEntryProcessor": {
+	},
+	"com.liferay.fragment.entry.processor.freemarker.FreeMarkerFragmentEntryProcessor": {
+	},
+	"instanceId": "",
+	"portletId": "com_liferay_login_web_portlet_LoginPortlet"
+}

--- a/modules/util/portal-tools-sample-sql-builder/src/main/resources/com/liferay/portal/tools/sample/sql/builder/dependencies/data/paragraph_configuration.json
+++ b/modules/util/portal-tools-sample-sql-builder/src/main/resources/com/liferay/portal/tools/sample/sql/builder/dependencies/data/paragraph_configuration.json
@@ -1,0 +1,66 @@
+{
+	"fieldSets": [
+		{
+			"fields": [
+				{
+					"dataType": "string",
+					"defaultValue": "left",
+					"label": "text-align",
+					"name": "textAlign",
+					"type": "select",
+					"typeOptions": {
+						"validValues": [
+							{
+								"value": "left"
+							},
+							{
+								"value": "center"
+							},
+							{
+								"value": "right"
+							},
+							{
+								"value": "justify"
+							}
+						]
+					}
+				},
+				{
+					"dataType": "string",
+					"defaultValue": "3",
+					"label": "margin-bottom",
+					"name": "marginBottom",
+					"type": "select",
+					"typeOptions": {
+						"validValues": [
+							{
+								"value": "0"
+							},
+							{
+								"value": "1"
+							},
+							{
+								"value": "2"
+							},
+							{
+								"value": "3"
+							},
+							{
+								"value": "4"
+							},
+							{
+								"value": "5"
+							}
+						]
+					}
+				},
+				{
+					"dataType": "object",
+					"label": "text-color",
+					"name": "textColor",
+					"type": "colorPalette"
+				}
+			]
+		}
+	]
+}

--- a/modules/util/portal-tools-sample-sql-builder/src/main/resources/com/liferay/portal/tools/sample/sql/builder/dependencies/data/paragraph_editValue.json
+++ b/modules/util/portal-tools-sample-sql-builder/src/main/resources/com/liferay/portal/tools/sample/sql/builder/dependencies/data/paragraph_editValue.json
@@ -1,0 +1,14 @@
+{
+	"com.liferay.fragment.entry.processor.background.image.BackgroundImageFragmentEntryProcessor": {
+	},
+	"com.liferay.fragment.entry.processor.editable.EditableFragmentEntryProcessor": {
+		"element-text": {
+			"config": {
+			},
+			"defaultValue": "A paragraph is a self-contained unit of a discourse in writing dealing with particular point or idea. Paragraphs are usually an expected part of formal writing, used to organize longer prose.",
+			"en_US": "${paragraphValue}"
+		}
+	},
+	"com.liferay.fragment.entry.processor.freemarker.FreeMarkerFragmentEntryProcessor": {
+	}
+}

--- a/modules/util/portal-tools-sample-sql-builder/src/main/resources/com/liferay/portal/tools/sample/sql/builder/dependencies/groups.ftl
+++ b/modules/util/portal-tools-sample-sql-builder/src/main/resources/com/liferay/portal/tools/sample/sql/builder/dependencies/groups.ftl
@@ -43,7 +43,11 @@
 		_parentDLFolderId=0
 	/>
 
-	<#assign groupLayoutModels = dataFactory.newGroupLayoutModels(groupId) />
+	<#assign
+		homePageContentLayoutModels = dataFactory.newContentPageLayoutModels(groupId, "welcome")
+
+		groupLayoutModels = dataFactory.newGroupLayoutModels(groupId)
+	/>
 
 	<#list groupLayoutModels as groupLayoutModel>
 		<@insertLayout _layoutModel=groupLayoutModel />
@@ -53,3 +57,5 @@
 
 	${csvFileWriter.write("repository", groupId + ", " + groupModel.name + "\n")}
 </#list>
+
+<#assign defaultSiteHomePageContentLayoutModels = dataFactory.newContentPageLayoutModels(guestGroupModel.groupId, "welcome") />

--- a/modules/util/portal-tools-sample-sql-builder/src/main/resources/com/liferay/portal/tools/sample/sql/builder/dependencies/groups.ftl
+++ b/modules/util/portal-tools-sample-sql-builder/src/main/resources/com/liferay/portal/tools/sample/sql/builder/dependencies/groups.ftl
@@ -43,11 +43,15 @@
 		_parentDLFolderId=0
 	/>
 
-	<#assign
-		homePageContentLayoutModels = dataFactory.newContentPageLayoutModels(groupId, "welcome")
+	<#assign homePageContentLayoutModels = dataFactory.newContentPageLayoutModels(groupId, "welcome") />
 
-		groupLayoutModels = dataFactory.newGroupLayoutModels(groupId)
+	<@insertContentPageLayout
+		_fragmentEntryLinkModels=dataFactory.newFragmentEntryLinkModels(homePageContentLayoutModels)
+		_layoutModels=homePageContentLayoutModels
+		_templateFileName="default-homepage-layout-definition.json"
 	/>
+
+	<#assign groupLayoutModels = dataFactory.newGroupLayoutModels(groupId) />
 
 	<#list groupLayoutModels as groupLayoutModel>
 		<@insertLayout _layoutModel=groupLayoutModel />
@@ -59,3 +63,9 @@
 </#list>
 
 <#assign defaultSiteHomePageContentLayoutModels = dataFactory.newContentPageLayoutModels(guestGroupModel.groupId, "welcome") />
+
+<@insertContentPageLayout
+	_fragmentEntryLinkModels=dataFactory.newFragmentEntryLinkModels(defaultSiteHomePageContentLayoutModels)
+	_layoutModels=defaultSiteHomePageContentLayoutModels
+	_templateFileName="default-homepage-layout-definition.json"
+/>

--- a/modules/util/portal-tools-sample-sql-builder/src/main/resources/com/liferay/portal/tools/sample/sql/builder/dependencies/groups.ftl
+++ b/modules/util/portal-tools-sample-sql-builder/src/main/resources/com/liferay/portal/tools/sample/sql/builder/dependencies/groups.ftl
@@ -49,9 +49,7 @@
 		_templateFileName="default-homepage-layout-definition.json"
 	/>
 
-	<#assign groupLayoutModels = dataFactory.newGroupLayoutModels(groupId) />
-
-	<#list groupLayoutModels as groupLayoutModel>
+	<#list dataFactory.newGroupLayoutModels(groupId) as groupLayoutModel>
 		<@insertLayout _layoutModel=groupLayoutModel />
 	</#list>
 

--- a/modules/util/portal-tools-sample-sql-builder/src/main/resources/com/liferay/portal/tools/sample/sql/builder/dependencies/groups.ftl
+++ b/modules/util/portal-tools-sample-sql-builder/src/main/resources/com/liferay/portal/tools/sample/sql/builder/dependencies/groups.ftl
@@ -9,8 +9,6 @@
 
 <#include "commerce_groups.ftl">
 
-<@insertLayout _layoutModel=dataFactory.newLayoutModel(guestGroupModel.groupId, "welcome", "com_liferay_login_web_portlet_LoginPortlet,", "com_liferay_hello_world_web_portlet_HelloWorldPortlet,") />
-
 <@insertGroup _groupModel=globalGroupModel />
 
 <@insertGroup _groupModel=guestGroupModel />

--- a/modules/util/portal-tools-sample-sql-builder/src/main/resources/com/liferay/portal/tools/sample/sql/builder/dependencies/macro.ftl
+++ b/modules/util/portal-tools-sample-sql-builder/src/main/resources/com/liferay/portal/tools/sample/sql/builder/dependencies/macro.ftl
@@ -53,6 +53,30 @@
 	${dataFactory.toInsertSQL(layoutPageTemplateStructureRelModel)}
 </#macro>
 
+<#macro insertContentPageLayout
+	_fragmentEntryLinkModels
+	_layoutModels
+	_templateFileName
+>
+	<#list _fragmentEntryLinkModels as fragmentEntryLinkModel>
+		${dataFactory.toInsertSQL(fragmentEntryLinkModel)}
+	</#list>
+
+	<#list _layoutModels as layoutModel>
+		${dataFactory.toInsertSQL(layoutModel)}
+
+		${dataFactory.toInsertSQL(dataFactory.newLayoutFriendlyURLModel(layoutModel))}
+
+		<#local layoutPageTemplateStructureModel = dataFactory.newLayoutPageTemplateStructureModel(layoutModel)>
+
+		${dataFactory.toInsertSQL(layoutPageTemplateStructureModel)}
+
+		<#local layoutPageTemplateStructureRelModel = dataFactory.newLayoutPageTemplateStructureRelModel(layoutModel, layoutPageTemplateStructureModel, _fragmentEntryLinkModels, _templateFileName)>
+
+		${dataFactory.toInsertSQL(layoutPageTemplateStructureRelModel)}
+	</#list>
+</#macro>
+
 <#macro insertDDMContent
 	_ddmStorageLinkId
 	_ddmStructureId


### PR DESCRIPTION
@slnn Please verify my last commit. 

Also, I can see some of the commerce related methods not using `_readFile` to read dependencies, like `StringUtil.read(getResourceInputStream("commerce_layouts.json"))`.
I can see that the `_readFile` and `StringUtil.read` has difference in handling line breaks. `_readFile` reads files into a single line, with each line in the original file separated by a space; `StringUtil.read` on the other hand keeps the line breaks in the original file, just normalizing them to Unix style new line `\n`.
I'm not sure why `_readFile` replaces line breaks with spaces, but as long as it works, could you also SF the commerce methods to apply `_readFile`?


﻿- LPS-113497 Add method to create LayoutModel for content page, prep next
- LPS-113497 Add method to create new FragmentEntryLinkModel, prep next
- LPS-113497 Add fragment-collection-contributor-basic-component as the dependency of SampleSQLBuilder, prep next
- LPS-113497 Pass InputStream to the method, prep next
- LPS-113497 Add method to get the inputStream of fragment component, prep next
- LPS-113497 Add generation of heading FragmentEntryLinkModel for each content page layout, prep next
- LPS-113497 Add generation of paragraph FragmentEntryLinkModel for each content page layout, prep next
- LPS-113497 Add generation of image fragmentEntryLinkModel for each content page layout, prep next
- LPS-113497 Add generation of LoginPortlet FragmentEntryLinkModel for each content page layout, prep next
- LPS-113497 Add method to create LayoutPageTemplateStructureRelModel, prep next
- LPS-113497 Generate content page as home page for each group
- LPS-113497 Remove the widget page layout generation for home page
- LPS-113497 SF, inline
- LPS-113497 SF, no need to use map
- LPS-113497 SF, do "getResourceAsStream" in a single method

