### PR TITLE
LPS-X Avoid to use stream to save performance

### DIFF
--- a/modules/apps/frontend-token/frontend-token-definition-impl/src/main/java/com/liferay/frontend/token/definition/internal/FrontendTokenImpl.java
+++ b/modules/apps/frontend-token/frontend-token-definition-impl/src/main/java/com/liferay/frontend/token/definition/internal/FrontendTokenImpl.java
@@ -24,8 +24,6 @@ import com.liferay.portal.kernel.json.JSONObject;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Locale;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 /**
  * @author Iván Zaera
@@ -89,13 +87,18 @@ public class FrontendTokenImpl implements FrontendToken {
 	public Collection<FrontendTokenMapping> getFrontendTokenMappings(
 		String type) {
 
-		Stream<FrontendTokenMapping> stream = _frontendTokenMappings.stream();
+		Collection<FrontendTokenMapping> frontendTokenMappings =
+			new ArrayList<>();
 
-		return stream.filter(
-			frontendTokenMapping -> type.equals(frontendTokenMapping.getType())
-		).collect(
-			Collectors.toList()
-		);
+		for (FrontendTokenMapping frontendTokenMapping :
+				_frontendTokenMappings) {
+
+			if (type.equals(frontendTokenMapping.getType())) {
+				frontendTokenMappings.add(frontendTokenMapping);
+			}
+		}
+
+		return frontendTokenMappings;
 	}
 
 	@Override


### PR DESCRIPTION
Hi @dantewang

When checking ScopedCSSVariablesTopHeadDynamicInclude, I see this one uses the stream API in a common path, as we know, the performance of stream is not so good, so I use a normal loop here. Not sure if it will bring noticeable improvement on Session Count

/cc @yuhai