### PR TITLE
[Remove "immediate = true" usage]Lps 168633

### DIFF
--- a/modules/apps/static/portal-bundle-blacklist/portal-bundle-blacklist-impl/src/main/java/com/liferay/portal/bundle/blacklist/internal/BundleBlacklist.java
+++ b/modules/apps/static/portal-bundle-blacklist/portal-bundle-blacklist-impl/src/main/java/com/liferay/portal/bundle/blacklist/internal/BundleBlacklist.java
@@ -56,7 +56,7 @@ import org.osgi.service.component.annotations.Reference;
  */
 @Component(
 	configurationPid = "com.liferay.portal.bundle.blacklist.internal.configuration.BundleBlacklistConfiguration",
-	immediate = true, service = BundleBlacklist.class
+	service = BundleBlacklist.class
 )
 public class BundleBlacklist {
 

--- a/modules/apps/static/portal-bundle-blacklist/portal-bundle-blacklist-impl/src/main/java/com/liferay/portal/bundle/blacklist/internal/BundleBlacklistManagerImpl.java
+++ b/modules/apps/static/portal-bundle-blacklist/portal-bundle-blacklist-impl/src/main/java/com/liferay/portal/bundle/blacklist/internal/BundleBlacklistManagerImpl.java
@@ -46,7 +46,7 @@ import org.osgi.service.component.annotations.Reference;
 /**
  * @author Preston Crary
  */
-@Component(immediate = true, service = BundleBlacklistManager.class)
+@Component(service = BundleBlacklistManager.class)
 public class BundleBlacklistManagerImpl implements BundleBlacklistManager {
 
 	@Override

--- a/modules/apps/static/portal-bundle-blacklist/portal-bundle-blacklist-impl/src/main/java/com/liferay/portal/bundle/blacklist/internal/upgrade/registry/BundleBlacklistImplUpgradeStepRegistrator.java
+++ b/modules/apps/static/portal-bundle-blacklist/portal-bundle-blacklist-impl/src/main/java/com/liferay/portal/bundle/blacklist/internal/upgrade/registry/BundleBlacklistImplUpgradeStepRegistrator.java
@@ -24,7 +24,7 @@ import org.osgi.service.component.annotations.Reference;
 /**
  * @author Alberto Chaparro
  */
-@Component(immediate = true, service = UpgradeStepRegistrator.class)
+@Component(service = UpgradeStepRegistrator.class)
 public class BundleBlacklistImplUpgradeStepRegistrator
 	implements UpgradeStepRegistrator {
 

--- a/modules/apps/static/portal-component-blacklist/portal-component-blacklist-impl/src/main/java/com/liferay/portal/component/blacklist/internal/ComponentBlacklistImpl.java
+++ b/modules/apps/static/portal-component-blacklist/portal-component-blacklist-impl/src/main/java/com/liferay/portal/component/blacklist/internal/ComponentBlacklistImpl.java
@@ -45,7 +45,7 @@ import org.osgi.service.component.runtime.dto.ComponentDescriptionDTO;
  */
 @Component(
 	configurationPid = "com.liferay.portal.component.blacklist.internal.configuration.ComponentBlacklistConfiguration",
-	configurationPolicy = ConfigurationPolicy.REQUIRE, immediate = true,
+	configurationPolicy = ConfigurationPolicy.REQUIRE,
 	service = ComponentBlacklist.class
 )
 public class ComponentBlacklistImpl implements ComponentBlacklist {

--- a/modules/apps/static/portal-component-blacklist/portal-component-blacklist-impl/src/main/java/com/liferay/portal/component/blacklist/internal/upgrade/registry/ComponentBlacklistImplUpgradeStepRegistrator.java
+++ b/modules/apps/static/portal-component-blacklist/portal-component-blacklist-impl/src/main/java/com/liferay/portal/component/blacklist/internal/upgrade/registry/ComponentBlacklistImplUpgradeStepRegistrator.java
@@ -24,7 +24,7 @@ import org.osgi.service.component.annotations.Reference;
 /**
  * @author Alberto Chaparro
  */
-@Component(immediate = true, service = UpgradeStepRegistrator.class)
+@Component(service = UpgradeStepRegistrator.class)
 public class ComponentBlacklistImplUpgradeStepRegistrator
 	implements UpgradeStepRegistrator {
 

--- a/modules/apps/static/portal-configuration/portal-configuration-persistence-impl/src/main/java/com/liferay/portal/configuration/persistence/internal/upgrade/registry/ConfigurationPersistenceUpgradeStepRegistrator.java
+++ b/modules/apps/static/portal-configuration/portal-configuration-persistence-impl/src/main/java/com/liferay/portal/configuration/persistence/internal/upgrade/registry/ConfigurationPersistenceUpgradeStepRegistrator.java
@@ -22,7 +22,7 @@ import org.osgi.service.component.annotations.Component;
 /**
  * @author Sam Ziemer
  */
-@Component(immediate = true, service = UpgradeStepRegistrator.class)
+@Component(service = UpgradeStepRegistrator.class)
 public class ConfigurationPersistenceUpgradeStepRegistrator
 	implements UpgradeStepRegistrator {
 

--- a/modules/apps/static/portal-k8s-agent/portal-k8s-agent-impl/src/main/java/com/liferay/portal/k8s/agent/internal/PortalK8sAgentImpl.java
+++ b/modules/apps/static/portal-k8s-agent/portal-k8s-agent-impl/src/main/java/com/liferay/portal/k8s/agent/internal/PortalK8sAgentImpl.java
@@ -70,7 +70,7 @@ import org.osgi.service.component.annotations.ReferencePolicyOption;
  */
 @Component(
 	configurationPid = "com.liferay.portal.k8s.agent.configuration.PortalK8sAgentConfiguration",
-	configurationPolicy = ConfigurationPolicy.REQUIRE, immediate = true,
+	configurationPolicy = ConfigurationPolicy.REQUIRE,
 	property = "portalK8sConfigurationPropertiesMutators.cardinality.minimum:Integer=3",
 	service = PortalK8sConfigMapModifier.class
 )

--- a/modules/apps/static/portal-k8s-agent/portal-k8s-agent-impl/src/main/java/com/liferay/portal/k8s/agent/internal/model/listener/VirtualHostModelListener.java
+++ b/modules/apps/static/portal-k8s-agent/portal-k8s-agent-impl/src/main/java/com/liferay/portal/k8s/agent/internal/model/listener/VirtualHostModelListener.java
@@ -41,7 +41,7 @@ import org.osgi.service.component.annotations.Reference;
  */
 @Component(
 	configurationPid = "com.liferay.portal.k8s.agent.configuration.PortalK8sAgentConfiguration",
-	configurationPolicy = ConfigurationPolicy.REQUIRE, immediate = true,
+	configurationPolicy = ConfigurationPolicy.REQUIRE,
 	service = ModelListener.class
 )
 public class VirtualHostModelListener extends BaseModelListener<VirtualHost> {

--- a/modules/apps/static/portal-k8s-agent/portal-k8s-agent-impl/src/main/java/com/liferay/portal/k8s/agent/internal/mutator/AnnotationsPortalK8sConfigurationPropertiesMutator.java
+++ b/modules/apps/static/portal-k8s-agent/portal-k8s-agent-impl/src/main/java/com/liferay/portal/k8s/agent/internal/mutator/AnnotationsPortalK8sConfigurationPropertiesMutator.java
@@ -29,9 +29,7 @@ import org.osgi.service.component.propertytypes.ServiceRanking;
 /**
  * @author Raymond Augé
  */
-@Component(
-	immediate = true, service = PortalK8sConfigurationPropertiesMutator.class
-)
+@Component(service = PortalK8sConfigurationPropertiesMutator.class)
 @ServiceRanking(1900)
 public class AnnotationsPortalK8sConfigurationPropertiesMutator
 	implements PortalK8sConfigurationPropertiesMutator {

--- a/modules/apps/static/portal-k8s-agent/portal-k8s-agent-impl/src/main/java/com/liferay/portal/k8s/agent/internal/mutator/BaseURLPortalK8sConfigurationPropertiesMutator.java
+++ b/modules/apps/static/portal-k8s-agent/portal-k8s-agent-impl/src/main/java/com/liferay/portal/k8s/agent/internal/mutator/BaseURLPortalK8sConfigurationPropertiesMutator.java
@@ -28,9 +28,7 @@ import org.osgi.service.component.propertytypes.ServiceRanking;
 /**
  * @author Raymond Augé
  */
-@Component(
-	immediate = true, service = PortalK8sConfigurationPropertiesMutator.class
-)
+@Component(service = PortalK8sConfigurationPropertiesMutator.class)
 @ServiceRanking(1800)
 public class BaseURLPortalK8sConfigurationPropertiesMutator
 	implements PortalK8sConfigurationPropertiesMutator {

--- a/modules/apps/static/portal-k8s-agent/portal-k8s-agent-impl/src/main/java/com/liferay/portal/k8s/agent/internal/mutator/LabelsPortalK8sConfigurationPropertiesMutator.java
+++ b/modules/apps/static/portal-k8s-agent/portal-k8s-agent-impl/src/main/java/com/liferay/portal/k8s/agent/internal/mutator/LabelsPortalK8sConfigurationPropertiesMutator.java
@@ -28,9 +28,7 @@ import org.osgi.service.component.propertytypes.ServiceRanking;
 /**
  * @author Raymond Augé
  */
-@Component(
-	immediate = true, service = PortalK8sConfigurationPropertiesMutator.class
-)
+@Component(service = PortalK8sConfigurationPropertiesMutator.class)
 @ServiceRanking(2000)
 public class LabelsPortalK8sConfigurationPropertiesMutator
 	implements PortalK8sConfigurationPropertiesMutator {

--- a/modules/apps/static/portal-lpkg-deployer/portal-lpkg-deployer-impl/src/main/java/com/liferay/portal/lpkg/deployer/internal/BytesURLProtocolSupport.java
+++ b/modules/apps/static/portal-lpkg-deployer/portal-lpkg-deployer-impl/src/main/java/com/liferay/portal/lpkg/deployer/internal/BytesURLProtocolSupport.java
@@ -39,7 +39,7 @@ import org.osgi.service.url.URLStreamHandlerService;
 /**
  * @author Shuyang Zhou
  */
-@Component(immediate = true, service = BytesURLProtocolSupport.class)
+@Component(service = BytesURLProtocolSupport.class)
 public class BytesURLProtocolSupport {
 
 	public URL putBytes(String id, byte[] bytes) {

--- a/modules/apps/static/portal-lpkg-deployer/portal-lpkg-deployer-impl/src/main/java/com/liferay/portal/lpkg/deployer/internal/DefaultLPKGDeployer.java
+++ b/modules/apps/static/portal-lpkg-deployer/portal-lpkg-deployer-impl/src/main/java/com/liferay/portal/lpkg/deployer/internal/DefaultLPKGDeployer.java
@@ -90,7 +90,7 @@ import org.osgi.util.tracker.BundleTracker;
 /**
  * @author Shuyang Zhou
  */
-@Component(immediate = true, service = LPKGDeployer.class)
+@Component(service = LPKGDeployer.class)
 public class DefaultLPKGDeployer implements LPKGDeployer {
 
 	@Override

--- a/modules/apps/static/portal-lpkg-deployer/portal-lpkg-deployer-impl/src/main/java/com/liferay/portal/lpkg/deployer/internal/DefaultLPKGVerifier.java
+++ b/modules/apps/static/portal-lpkg-deployer/portal-lpkg-deployer-impl/src/main/java/com/liferay/portal/lpkg/deployer/internal/DefaultLPKGVerifier.java
@@ -37,7 +37,7 @@ import org.osgi.service.component.annotations.Component;
 /**
  * @author Shuyang Zhou
  */
-@Component(immediate = true, service = LPKGVerifier.class)
+@Component(service = LPKGVerifier.class)
 public class DefaultLPKGVerifier implements LPKGVerifier {
 
 	@Override

--- a/modules/apps/static/portal-lpkg-deployer/portal-lpkg-deployer-impl/src/main/java/com/liferay/portal/lpkg/deployer/internal/LPKGArtifactInstaller.java
+++ b/modules/apps/static/portal-lpkg-deployer/portal-lpkg-deployer-impl/src/main/java/com/liferay/portal/lpkg/deployer/internal/LPKGArtifactInstaller.java
@@ -59,7 +59,7 @@ import org.osgi.service.url.URLStreamHandlerService;
 /**
  * @author Shuyang Zhou
  */
-@Component(immediate = true, service = FileInstaller.class)
+@Component(service = FileInstaller.class)
 public class LPKGArtifactInstaller implements FileInstaller {
 
 	@Override

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-servlet-context-helper-impl/src/main/java/com/liferay/portal/osgi/web/servlet/context/helper/internal/ServletContextHelperFactoryImpl.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-servlet-context-helper-impl/src/main/java/com/liferay/portal/osgi/web/servlet/context/helper/internal/ServletContextHelperFactoryImpl.java
@@ -40,7 +40,7 @@ import org.xml.sax.SAXNotSupportedException;
 /**
  * @author Raymond Augé
  */
-@Component(immediate = true, service = ServletContextHelperFactory.class)
+@Component(service = ServletContextHelperFactory.class)
 public class ServletContextHelperFactoryImpl
 	implements ServletContextHelperFactory {
 

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-servlet-jsp-compiler/src/main/java/com/liferay/portal/osgi/web/servlet/jsp/compiler/internal/JSPServletFactoryImpl.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-servlet-jsp-compiler/src/main/java/com/liferay/portal/osgi/web/servlet/jsp/compiler/internal/JSPServletFactoryImpl.java
@@ -50,7 +50,7 @@ import org.osgi.util.tracker.BundleTrackerCustomizer;
 /**
  * @author Preston Crary
  */
-@Component(immediate = true, service = JSPServletFactory.class)
+@Component(service = JSPServletFactory.class)
 public class JSPServletFactoryImpl implements JSPServletFactory {
 
 	@Override

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-servlet-jsp-compiler/src/main/java/com/liferay/portal/osgi/web/servlet/jsp/compiler/internal/JSPTaglibHelperImpl.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-servlet-jsp-compiler/src/main/java/com/liferay/portal/osgi/web/servlet/jsp/compiler/internal/JSPTaglibHelperImpl.java
@@ -36,7 +36,7 @@ import org.osgi.service.component.annotations.Component;
 /**
  * @author Tina Tian
  */
-@Component(immediate = true, service = JSPTaglibHelper.class)
+@Component(service = JSPTaglibHelper.class)
 public class JSPTaglibHelperImpl implements JSPTaglibHelper {
 
 	@Override

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-servlet-jsp-compiler/src/main/java/com/liferay/portal/osgi/web/servlet/jsp/compiler/internal/JspReloader.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-servlet-jsp-compiler/src/main/java/com/liferay/portal/osgi/web/servlet/jsp/compiler/internal/JspReloader.java
@@ -34,7 +34,7 @@ import org.osgi.service.component.annotations.Deactivate;
 /**
  * @author Matthew Tambara
  */
-@Component(immediate = true, service = {})
+@Component(service = {})
 public class JspReloader {
 
 	@Activate

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-wab-extender/src/main/java/com/liferay/portal/osgi/web/wab/extender/internal/WabFactory.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-wab-extender/src/main/java/com/liferay/portal/osgi/web/wab/extender/internal/WabFactory.java
@@ -49,8 +49,7 @@ import org.osgi.util.tracker.BundleTrackerCustomizer;
  */
 @Component(
 	configurationPid = "com.liferay.portal.osgi.web.wab.extender.internal.configuration.WabExtenderConfiguration",
-	configurationPolicy = ConfigurationPolicy.OPTIONAL, immediate = true,
-	service = {}
+	configurationPolicy = ConfigurationPolicy.OPTIONAL, service = {}
 )
 public class WabFactory
 	implements BundleTrackerCustomizer<WabFactory.WABExtension> {

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-wab-extender/src/main/java/com/liferay/portal/osgi/web/wab/extender/internal/adapter/HttpAdapter.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-wab-extender/src/main/java/com/liferay/portal/osgi/web/wab/extender/internal/adapter/HttpAdapter.java
@@ -53,7 +53,7 @@ import org.osgi.service.http.runtime.HttpServiceRuntimeConstants;
 /**
  * @author Raymond Augé
  */
-@Component(immediate = true, service = {})
+@Component(service = {})
 public class HttpAdapter {
 
 	@Activate

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-wab-generator-impl/src/main/java/com/liferay/portal/osgi/web/wab/generator/internal/WabGenerator.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-wab-generator-impl/src/main/java/com/liferay/portal/osgi/web/wab/generator/internal/WabGenerator.java
@@ -70,7 +70,6 @@ import org.osgi.util.tracker.BundleTracker;
  * @author Raymond Augé
  */
 @Component(
-	immediate = true,
 	service = com.liferay.portal.osgi.web.wab.generator.WabGenerator.class
 )
 public class WabGenerator

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-wab-reference-support/src/main/java/com/liferay/portal/osgi/web/wab/reference/support/internal/WabDirURLStreamHandlerService.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-wab-reference-support/src/main/java/com/liferay/portal/osgi/web/wab/reference/support/internal/WabDirURLStreamHandlerService.java
@@ -55,7 +55,6 @@ import org.osgi.service.url.URLStreamHandlerService;
  * @author Gregory Amerson
  */
 @Component(
-	immediate = true,
 	property = URLConstants.URL_HANDLER_PROTOCOL + "=webbundledir",
 	service = URLStreamHandlerService.class
 )

--- a/modules/apps/static/portal-startup-monitor/portal-startup-monitor/src/main/java/com/liferay/portal/startup/monitor/internal/PortalStartupMonitor.java
+++ b/modules/apps/static/portal-startup-monitor/portal-startup-monitor/src/main/java/com/liferay/portal/startup/monitor/internal/PortalStartupMonitor.java
@@ -31,7 +31,7 @@ import org.osgi.service.component.annotations.ReferencePolicy;
 /**
  * @author Matthew Tambara
  */
-@Component(immediate = true, service = {})
+@Component(service = {})
 public class PortalStartupMonitor {
 
 	@Reference(


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-168633

This one will remove "immediate = true" from these static modules of core-infrastructure:

modules/apps/static/portal-bundle-blacklist
modules/apps/static/portal-component-blacklist
modules/apps/static/portal-configuration
modules/apps/static/portal-k8s-agent
modules/apps/static/portal-lpkg-deployer
modules/apps/static/portal-osgi-web
modules/apps/static/portal-startup-monitor

Note: exclude the PortletTracker from modules/apps/static/portal-osgi-web since removing immediate=true from it may cause it never to be started since no one will reference it, but portal needs it to be started at the first.