### PR TITLE
LPD-X Apply jvmarg for SampleSQLBuilder to avoid these InaccessibleOb…

### DIFF
--- a/benchmarks/build.xml
+++ b/benchmarks/build.xml
@@ -13,6 +13,8 @@
 			dir="."
 			fork="true"
 		>
+			<jvmarg value="--add-opens=java.base/java.lang.invoke=ALL-UNNAMED" />
+			<jvmarg value="--add-opens=java.base/java.lang.reflect=ALL-UNNAMED" />
 			<classpath>
 				<fileset
 					dir="${sdk.dir}/dist"

--- a/modules/util/portal-tools-sample-sql-builder/build.gradle
+++ b/modules/util/portal-tools-sample-sql-builder/build.gradle
@@ -99,6 +99,10 @@ dependencies {
 	compileOnly project(":core:petra:petra-string")
 }
 
+test {
+	jvmArgs '--add-opens=java.base/java.lang.invoke=ALL-UNNAMED', '--add-opens=java.base/java.lang.reflect=ALL-UNNAMED'
+}
+
 writeReleases {
 	dependsOn configurations.compileInclude
 

--- a/modules/util/portal-tools-sample-sql-builder/src/main/java/com/liferay/portal/tools/sample/sql/builder/SampleSQLBuilderLauncher.java
+++ b/modules/util/portal-tools-sample-sql-builder/src/main/java/com/liferay/portal/tools/sample/sql/builder/SampleSQLBuilderLauncher.java
@@ -44,7 +44,8 @@ public class SampleSQLBuilderLauncher {
 		File tempDir = FileUtil.createTempFolder();
 
 		ClassLoader classLoader = new URLClassLoader(
-			_getURLs(contextClassLoader, tempDir.toPath()), null);
+			_getURLs(contextClassLoader, tempDir.toPath()),
+			ClassLoader.getPlatformClassLoader());
 
 		try (SafeCloseable safeCloseable = ThreadContextClassLoaderUtil.swap(
 				classLoader)) {


### PR DESCRIPTION
…jectException

Caused by: java.lang.reflect.InaccessibleObjectException: Unable to make field static final java.lang.invoke.MethodHandles$Lookup java.lang.invoke.MethodHandles$Lookup.IMPL_LOOKUP accessible: module java.base does not "opens java.lang.invoke" to unnamed module @5f565482

Caused by: java.lang.reflect.InaccessibleObjectException: Unable to make field protected java.lang.reflect.InvocationHandler java.lang.reflect.Proxy.h accessible: module java.base does not "opens java.lang.reflect" to unnamed module @244038d0